### PR TITLE
fix: remove injected postinstall script from published package.json

### DIFF
--- a/.changeset/eager-dream-727.md
+++ b/.changeset/eager-dream-727.md
@@ -1,0 +1,7 @@
+---
+"@savvy-web/commitlint": patch
+---
+
+## Bug Fixes
+
+Remove injected postinstall script from published package.json. Fixes #62.

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -17,9 +17,7 @@ export default NodeLibraryBuilder.create({
 		delete pkg.packageManager;
 		delete pkg.devEngines;
 		delete pkg.config;
-		pkg.scripts = {
-			postinstall: "savvy-commit check --quiet || true",
-		};
+		delete pkg.scripts;
 		return pkg;
 	},
 });


### PR DESCRIPTION
## Summary

- Remove the `postinstall` script injection from the `transform` function in `rslib.config.ts`
- The published `package.json` will no longer include a `postinstall` script, avoiding supply chain risk flags from security scanners

Closes #62

## Test plan

- [ ] Verify `pnpm run build` produces a `package.json` without `postinstall` in `scripts`
- [ ] Confirm lint and typecheck pass

Signed-off-by: C. Spencer Beggs <spencer@savvyweb.systems>