### PR TITLE
fix(hooks): detect package manager and config in post-commit-verify

### DIFF
--- a/.changeset/calm-rivers-sleep.md
+++ b/.changeset/calm-rivers-sleep.md
@@ -1,0 +1,8 @@
+---
+"@savvy-web/commitlint": patch
+---
+
+## Bug Fixes
+
+- Fixed `post-commit-verify` hook failing on non-pnpm projects by detecting the consumer's package manager from `package.json#packageManager` and lockfile presence, then building the correct invocation (`pnpm exec`, `yarn exec`, `bunx`, or `npx --no --`).
+- Fixed `post-commit-verify` hook ignoring custom commitlint config paths by reading the `--config` argument from the managed section of `.husky/commit-msg` (the source of truth written by `savvy-commit init`). Falls back to cosmiconfig auto-discovery when `.husky/commit-msg` is absent.

--- a/.claude/design/commitlint/overview.md
+++ b/.claude/design/commitlint/overview.md
@@ -3,8 +3,8 @@ status: current
 module: commitlint
 category: architecture
 created: 2026-02-02
-updated: 2026-04-28
-last-synced: 2026-04-28
+updated: 2026-04-29
+last-synced: 2026-04-29
 completeness: 92
 related: []
 dependencies:
@@ -313,6 +313,8 @@ package/
         signing.ts                # GPG/SSH signing diagnostic (format, autoSign, key resolution, agent)
         cache.ts                  # JSON file cache with TTL (atomic-ish writes)
         open-issues.ts            # gh-CLI-backed open issues, cached at .claude/cache/issues.json
+        package-manager.ts        # Detect pm from package.json#packageManager or lockfile (pnpm > yarn > bun > npm)
+        commitlint-config.ts      # Extract --config path from .husky/commit-msg managed section
       rules/
         types.ts                  # Rule<Input,Ctx>, RuleHit, partitionHits
         forbidden-content.ts      # deny: markdown headers / code fences in body
@@ -942,6 +944,16 @@ Diagnostics shared across subcommands (`package/src/hook/diagnostics/`):
   `gh issue list ... --json number,title`, caches at
   `.claude/cache/issues.json` for 600 s. SessionStart fetches; PreToolUse
   reads the cache only (never network).
+- `package-manager.ts` — detects the package manager for the current repo,
+  preferring `package.json#packageManager` and falling back to lockfile
+  presence in priority order (`pnpm-lock.yaml` > `yarn.lock` > `bun.lock` >
+  `npm`). Used by `post-commit-verify` to build a portable commitlint
+  invocation that matches what the husky hook would run.
+- `commitlint-config.ts` — parses the `--config` argument out of
+  `.husky/commit-msg` (handles `$ROOT/`, `${ROOT}/`, single/double-quoted,
+  unquoted, and absolute forms). Returns `null` if the file is absent or
+  does not pin a config path. `post-commit-verify` uses this so its replay
+  uses the same config the commit-time hook used.
 
 ---
 
@@ -1013,12 +1025,24 @@ cache and any future plugin caches live.
 commit-related and the response was not interrupted. It then forwards the
 envelope to `savvy-commit hook post-commit-verify`, which:
 
-1. Replays `pnpm exec commitlint --last` (errors → "commitlint failed").
+1. Resolves the repo root (`git rev-parse --show-toplevel`, falling back to
+   `process.cwd()`), detects the package manager via
+   `diagnostics/package-manager.ts`, and reads the husky-managed config path
+   via `diagnostics/commitlint-config.ts`. The pure helper
+   `buildCommitlintInvocation(pm, configPath)` then assembles the runner
+   prefix (`pnpm exec` / `yarn exec` / `bunx` / `npx --no --`) followed by
+   `commitlint --config <path> --last` (omitting `--config` when the husky
+   hook has no pinned path). The command is spawned with `cwd: root`. Any
+   non-zero exit becomes "commitlint failed".
 2. Reads `git log -1 --format=%G?` (signature status) and combines with the
    signing diagnostic to advise on unsigned commits when
    `commit.gpgsign=true`, or on bad/expired/revoked/missing-key statuses.
 3. If the branch implies a ticket id and the commit body has no
    `Closes/Fixes/Resolves #N` trailer, advises an `--amend --trailer` fix.
+
+This keeps the verifier's replay consistent with whatever the husky
+`commit-msg` hook would actually run, and portable across consumer projects
+that use a non-pnpm package manager.
 
 `user-prompt-submit.sh` runs a regex pre-filter
 (`commit | committing | ship it | wrap up | create/open a pr | finalize | squash | amend`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,8 @@ bats plugin/hooks/__test__/match-safe-bash.bats
   hook envelopes (`envelope.ts`), JSON output builders (`output.ts`), the
   shell-quote-based `parse-bash-command.ts`, the `HookSilencer` Layer
   (`silence-logger.ts`), `diagnostics/` (branch, signing, cache,
-  open-issues), and a `rules/` pipeline of typed `Rule<Input, Ctx>` units
+  open-issues, package-manager, commitlint-config), and a `rules/` pipeline
+  of typed `Rule<Input, Ctx>` units
   partitioned into `deny` / `advise` hits.
 
 ### Plugin Layout

--- a/package/src/cli/commands/hooks/__test__/post-commit-verify.test.ts
+++ b/package/src/cli/commands/hooks/__test__/post-commit-verify.test.ts
@@ -1,5 +1,42 @@
 import { describe, expect, it } from "vitest";
-import { buildPostCommitAdvice } from "../post-commit-verify.js";
+import { buildCommitlintInvocation, buildPostCommitAdvice } from "../post-commit-verify.js";
+
+describe("buildCommitlintInvocation", () => {
+	it("uses pnpm exec for pnpm projects", () => {
+		expect(buildCommitlintInvocation("pnpm", "/r/cl.ts")).toEqual({
+			command: "pnpm",
+			args: ["exec", "commitlint", "--config", "/r/cl.ts", "--last"],
+		});
+	});
+
+	it("uses yarn exec for yarn projects", () => {
+		expect(buildCommitlintInvocation("yarn", "/r/cl.ts")).toEqual({
+			command: "yarn",
+			args: ["exec", "commitlint", "--config", "/r/cl.ts", "--last"],
+		});
+	});
+
+	it("uses bunx for bun projects", () => {
+		expect(buildCommitlintInvocation("bun", "/r/cl.ts")).toEqual({
+			command: "bunx",
+			args: ["commitlint", "--config", "/r/cl.ts", "--last"],
+		});
+	});
+
+	it("uses npx --no -- for npm projects", () => {
+		expect(buildCommitlintInvocation("npm", "/r/cl.ts")).toEqual({
+			command: "npx",
+			args: ["--no", "--", "commitlint", "--config", "/r/cl.ts", "--last"],
+		});
+	});
+
+	it("omits --config when configPath is null", () => {
+		expect(buildCommitlintInvocation("pnpm", null)).toEqual({
+			command: "pnpm",
+			args: ["exec", "commitlint", "--last"],
+		});
+	});
+});
 
 describe("buildPostCommitAdvice", () => {
 	it("emits commitlint-fail line when commitlint output indicates failure", () => {

--- a/package/src/cli/commands/hooks/post-commit-verify.ts
+++ b/package/src/cli/commands/hooks/post-commit-verify.ts
@@ -9,6 +9,9 @@ import { promisify } from "node:util";
 import { Command } from "@effect/cli";
 import { Effect } from "effect";
 import { readBranchInfo } from "../../../hook/diagnostics/branch.js";
+import { readCommitlintConfigPath } from "../../../hook/diagnostics/commitlint-config.js";
+import type { PackageManager } from "../../../hook/diagnostics/package-manager.js";
+import { detectPackageManager } from "../../../hook/diagnostics/package-manager.js";
 import { readSigningDiagnostic } from "../../../hook/diagnostics/signing.js";
 import { postToolUseAdvise } from "../../../hook/output.js";
 import { hasClosingTrailer } from "../../../hook/rules/closes-trailer.js";
@@ -54,9 +57,41 @@ export function buildPostCommitAdvice(i: PostCommitInputs): string | null {
 	return lines.length === 0 ? null : lines.join("\n\n");
 }
 
-async function runCommitlintLast(): Promise<boolean> {
+export interface CommitlintInvocation {
+	command: string;
+	args: string[];
+}
+
+export function buildCommitlintInvocation(pm: PackageManager, configPath: string | null): CommitlintInvocation {
+	const tail = configPath ? ["commitlint", "--config", configPath, "--last"] : ["commitlint", "--last"];
+	switch (pm) {
+		case "pnpm":
+			return { command: "pnpm", args: ["exec", ...tail] };
+		case "yarn":
+			return { command: "yarn", args: ["exec", ...tail] };
+		case "bun":
+			return { command: "bunx", args: tail };
+		case "npm":
+			return { command: "npx", args: ["--no", "--", ...tail] };
+	}
+}
+
+async function getRepoRoot(): Promise<string> {
 	try {
-		await execFileP("pnpm", ["exec", "commitlint", "--last"]);
+		const { stdout } = await execFileP("git", ["rev-parse", "--show-toplevel"]);
+		return stdout.trim();
+	} catch {
+		return process.cwd();
+	}
+}
+
+async function runCommitlintLast(): Promise<boolean> {
+	const root = await getRepoRoot();
+	const pm = await detectPackageManager(root);
+	const configPath = await readCommitlintConfigPath(root);
+	const { command, args } = buildCommitlintInvocation(pm, configPath);
+	try {
+		await execFileP(command, args, { cwd: root });
 		return false;
 	} catch {
 		return true;

--- a/package/src/hook/__test__/diagnostics/commitlint-config.test.ts
+++ b/package/src/hook/__test__/diagnostics/commitlint-config.test.ts
@@ -1,0 +1,77 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parseHuskyConfigPath, readCommitlintConfigPath } from "../../diagnostics/commitlint-config.js";
+
+const husky = (line: string) => `#!/usr/bin/env sh\nROOT=$(git rev-parse --show-toplevel)\n${line}\n`;
+
+describe("parseHuskyConfigPath", () => {
+	it("extracts the path from a $ROOT-prefixed --config arg", () => {
+		const content = husky('pnpm exec commitlint --config "$ROOT/lib/configs/commitlint.config.ts" --edit "$1"');
+		expect(parseHuskyConfigPath(content, "/repo")).toBe("/repo/lib/configs/commitlint.config.ts");
+	});
+
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash variable syntax
+	it("extracts the path from a ${ROOT}-prefixed --config arg", () => {
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash variable syntax
+		const content = husky('pnpm exec commitlint --config "${ROOT}/commitlint.config.ts" --edit "$1"');
+		expect(parseHuskyConfigPath(content, "/repo")).toBe("/repo/commitlint.config.ts");
+	});
+
+	it("supports single-quoted paths", () => {
+		const content = husky("pnpm exec commitlint --config '$ROOT/cl.ts' --edit \"$1\"");
+		expect(parseHuskyConfigPath(content, "/repo")).toBe("/repo/cl.ts");
+	});
+
+	it("supports unquoted paths", () => {
+		const content = husky('pnpm exec commitlint --config $ROOT/cl.ts --edit "$1"');
+		expect(parseHuskyConfigPath(content, "/repo")).toBe("/repo/cl.ts");
+	});
+
+	it("preserves absolute paths", () => {
+		const content = husky('pnpm exec commitlint --config "/etc/cl.ts" --edit "$1"');
+		expect(parseHuskyConfigPath(content, "/repo")).toBe("/etc/cl.ts");
+	});
+
+	it("resolves a relative path without a $ROOT prefix", () => {
+		const content = husky('pnpm exec commitlint --config "lib/configs/cl.ts" --edit "$1"');
+		expect(parseHuskyConfigPath(content, "/repo")).toBe("/repo/lib/configs/cl.ts");
+	});
+
+	it("returns null when there is no --config flag", () => {
+		const content = husky('pnpm exec commitlint --edit "$1"');
+		expect(parseHuskyConfigPath(content, "/repo")).toBeNull();
+	});
+});
+
+describe("readCommitlintConfigPath", () => {
+	let dir: string;
+
+	beforeEach(async () => {
+		dir = await mkdtemp(join(tmpdir(), "savvy-cl-"));
+	});
+
+	afterEach(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	it("reads the path from .husky/commit-msg", async () => {
+		await mkdir(join(dir, ".husky"), { recursive: true });
+		await writeFile(
+			join(dir, ".husky", "commit-msg"),
+			husky('pnpm exec commitlint --config "$ROOT/lib/configs/commitlint.config.ts" --edit "$1"'),
+		);
+		expect(await readCommitlintConfigPath(dir)).toBe(resolve(dir, "lib/configs/commitlint.config.ts"));
+	});
+
+	it("returns null when .husky/commit-msg does not exist", async () => {
+		expect(await readCommitlintConfigPath(dir)).toBeNull();
+	});
+
+	it("returns null when the hook has no --config arg", async () => {
+		await mkdir(join(dir, ".husky"), { recursive: true });
+		await writeFile(join(dir, ".husky", "commit-msg"), husky('pnpm exec commitlint --edit "$1"'));
+		expect(await readCommitlintConfigPath(dir)).toBeNull();
+	});
+});

--- a/package/src/hook/__test__/diagnostics/package-manager.test.ts
+++ b/package/src/hook/__test__/diagnostics/package-manager.test.ts
@@ -1,0 +1,86 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	detectFromLockfiles,
+	detectPackageManager,
+	parsePackageManagerField,
+} from "../../diagnostics/package-manager.js";
+
+describe("parsePackageManagerField", () => {
+	it.each([
+		["pnpm@9.0.0", "pnpm"],
+		["yarn@1.22.19", "yarn"],
+		["bun@1.0.0", "bun"],
+		["npm@10.2.0", "npm"],
+	])("extracts %s -> %s", (field, expected) => {
+		expect(parsePackageManagerField(JSON.stringify({ packageManager: field }))).toBe(expected);
+	});
+
+	it("returns null when packageManager is missing", () => {
+		expect(parsePackageManagerField(JSON.stringify({}))).toBeNull();
+	});
+
+	it("returns null when packageManager is an unknown tool", () => {
+		expect(parsePackageManagerField(JSON.stringify({ packageManager: "deno@1.0.0" }))).toBeNull();
+	});
+
+	it("returns null when packageManager is not a string", () => {
+		expect(parsePackageManagerField(JSON.stringify({ packageManager: 42 }))).toBeNull();
+	});
+
+	it("returns null when JSON is malformed", () => {
+		expect(parsePackageManagerField("{ not json")).toBeNull();
+	});
+});
+
+describe("detectFromLockfiles", () => {
+	it("prefers pnpm when pnpm-lock.yaml is present", () => {
+		expect(detectFromLockfiles({ pnpm: true, yarn: true, bun: true })).toBe("pnpm");
+	});
+
+	it("returns yarn when only yarn.lock is present", () => {
+		expect(detectFromLockfiles({ pnpm: false, yarn: true, bun: false })).toBe("yarn");
+	});
+
+	it("returns bun when only bun.lock is present", () => {
+		expect(detectFromLockfiles({ pnpm: false, yarn: false, bun: true })).toBe("bun");
+	});
+
+	it("falls back to npm when no lockfile is present", () => {
+		expect(detectFromLockfiles({ pnpm: false, yarn: false, bun: false })).toBe("npm");
+	});
+});
+
+describe("detectPackageManager", () => {
+	let dir: string;
+
+	beforeEach(async () => {
+		dir = await mkdtemp(join(tmpdir(), "savvy-pm-"));
+	});
+
+	afterEach(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	it("uses packageManager field when present", async () => {
+		await writeFile(join(dir, "package.json"), JSON.stringify({ packageManager: "yarn@1.22.19" }));
+		expect(await detectPackageManager(dir)).toBe("yarn");
+	});
+
+	it("falls back to lockfile when packageManager field is missing", async () => {
+		await writeFile(join(dir, "package.json"), JSON.stringify({}));
+		await writeFile(join(dir, "bun.lock"), "");
+		expect(await detectPackageManager(dir)).toBe("bun");
+	});
+
+	it("falls back to lockfile when package.json is missing", async () => {
+		await writeFile(join(dir, "pnpm-lock.yaml"), "");
+		expect(await detectPackageManager(dir)).toBe("pnpm");
+	});
+
+	it("returns npm when nothing is present", async () => {
+		expect(await detectPackageManager(dir)).toBe("npm");
+	});
+});

--- a/package/src/hook/diagnostics/commitlint-config.ts
+++ b/package/src/hook/diagnostics/commitlint-config.ts
@@ -1,0 +1,38 @@
+/**
+ * Resolve the commitlint config path used by the husky commit-msg hook.
+ *
+ * The husky hook is the source of truth: `init` writes the chosen path into
+ * its managed section as `--config "$ROOT/<path>"`. The post-commit verifier
+ * extracts that same path so its replay matches the committed-time invocation.
+ *
+ * @internal
+ */
+import { readFile } from "node:fs/promises";
+import { isAbsolute, join, resolve } from "node:path";
+
+const CONFIG_FLAG_RE = /--config\s+(?:"([^"]+)"|'([^']+)'|(\S+))/;
+// biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash variable syntax
+const ROOT_PREFIXES = ["$ROOT/", "${ROOT}/"];
+
+export function parseHuskyConfigPath(huskyContent: string, root: string): string | null {
+	const m = huskyContent.match(CONFIG_FLAG_RE);
+	if (!m) return null;
+	let raw = m[1] ?? m[2] ?? m[3] ?? "";
+	if (!raw) return null;
+	for (const prefix of ROOT_PREFIXES) {
+		if (raw.startsWith(prefix)) {
+			raw = raw.slice(prefix.length);
+			break;
+		}
+	}
+	return isAbsolute(raw) ? raw : resolve(root, raw);
+}
+
+export async function readCommitlintConfigPath(root: string): Promise<string | null> {
+	try {
+		const content = await readFile(join(root, ".husky/commit-msg"), "utf8");
+		return parseHuskyConfigPath(content, root);
+	} catch {
+		return null;
+	}
+}

--- a/package/src/hook/diagnostics/package-manager.ts
+++ b/package/src/hook/diagnostics/package-manager.ts
@@ -1,0 +1,59 @@
+/**
+ * Package manager detection for the commit-time hooks.
+ *
+ * Mirrors the husky hook detection: prefer `package.json#packageManager`,
+ * fall back to lockfile presence in priority order pnpm \> yarn \> bun \> npm.
+ *
+ * @internal
+ */
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export type PackageManager = "pnpm" | "yarn" | "bun" | "npm";
+
+const VALID_PMS: ReadonlySet<string> = new Set(["pnpm", "yarn", "bun", "npm"]);
+
+export interface LockfilePresence {
+	pnpm: boolean;
+	yarn: boolean;
+	bun: boolean;
+}
+
+export function parsePackageManagerField(packageJsonContent: string): PackageManager | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(packageJsonContent);
+	} catch {
+		return null;
+	}
+	const field =
+		typeof parsed === "object" && parsed !== null && "packageManager" in parsed
+			? (parsed as { packageManager?: unknown }).packageManager
+			: undefined;
+	if (typeof field !== "string" || field.length === 0) return null;
+	const name = field.split("@")[0];
+	return VALID_PMS.has(name) ? (name as PackageManager) : null;
+}
+
+export function detectFromLockfiles(presence: LockfilePresence): PackageManager {
+	if (presence.pnpm) return "pnpm";
+	if (presence.yarn) return "yarn";
+	if (presence.bun) return "bun";
+	return "npm";
+}
+
+export async function detectPackageManager(root: string): Promise<PackageManager> {
+	try {
+		const content = await readFile(join(root, "package.json"), "utf8");
+		const fromField = parsePackageManagerField(content);
+		if (fromField !== null) return fromField;
+	} catch {
+		// fall through to lockfile detection
+	}
+	return detectFromLockfiles({
+		pnpm: existsSync(join(root, "pnpm-lock.yaml")),
+		yarn: existsSync(join(root, "yarn.lock")),
+		bun: existsSync(join(root, "bun.lock")),
+	});
+}


### PR DESCRIPTION
Summary

Fixes the post-commit-verify hook which hardcoded `pnpm exec commitlint --last` and never passed `--config`, so it reported false-positive failures on yarn/bun/npm projects and on projects whose commitlint config lives outside cosmiconfig's search path (e.g. `lib/configs/commitlint.config.ts`).

- Adds `hook/diagnostics/package-manager.ts` that detects pnpm/yarn/bun/npm from `package.json#packageManager`, falling back to lockfile presence in priority order pnpm > yarn > bun > npm. Same algorithm the husky hook uses.
- Adds `hook/diagnostics/commitlint-config.ts` that extracts the `--config` path from the managed section of `.husky/commit-msg`, the source of truth written by `savvy-commit init`. Falls back to cosmiconfig auto-discovery when the husky hook is absent.
- Rewrites `runCommitlintLast` to resolve the repo root via `git rev-parse`, detect the PM, read the husky-derived config path, and dispatch via `pnpm exec`, `yarn exec`, `bunx`, or `npx --no --` followed by `commitlint --config <path> --last`.
- Exports `buildCommitlintInvocation` as a pure helper so the dispatch table is unit-testable.

Test plan

- [x] `pnpm vitest run` (268 tests pass; 25 new across PM detection, husky config parsing, and dispatch table)
- [x] `pnpm run typecheck` clean
- [x] `pnpm exec biome check` on touched files clean
- [ ] After this lands and rebuilds, the post-commit hook should stop firing false-positive `commitlint --last` warnings on this repo

Signed-off-by: C. Spencer Beggs <spencer@savvyweb.systems>