### PR TITLE
feat: split husky hooks into shared savvy-base, savvy-commit, and savvy-hooks sections

### DIFF
--- a/.changeset/clever-cups-laugh.md
+++ b/.changeset/clever-cups-laugh.md
@@ -1,0 +1,14 @@
+---
+"@savvy-web/commitlint": patch
+---
+
+## Dependencies
+
+| Dependency               | Type          | Action  | From    | To      |
+| ------------------------ | ------------- | ------- | ------- | ------- |
+| zod                      | dependency    | removed | ^4.4.3  | —       |
+| @savvy-web/silk-effects  | dependency    | updated | ^0.4.1  | ^0.5.0  |
+| shell-quote              | dependency    | updated | ^1.8.3  | ^1.8.4  |
+| workspaces-effect        | dependency    | updated | ^0.5.0  | ^1.1.0  |
+| @commitlint/types        | devDependency | updated | ^20.5.0 | ^21.0.1 |
+| @savvy-web/rslib-builder | devDependency | updated | ^0.20.7 | ^0.20.8 |

--- a/.changeset/fancy-bears-swim.md
+++ b/.changeset/fancy-bears-swim.md
@@ -1,0 +1,77 @@
+---
+"@savvy-web/commitlint": minor
+---
+
+## Features
+
+### `savvy-commit init`: ordered managed sections in commit-msg hook
+
+`savvy-commit init` now writes `.husky/commit-msg` as an ordered pair of
+silk-effects managed sections:
+
+1. A shared `savvy-base` preamble — `ROOT`, `in_ci()`, `detect_pm()`,
+   `PM`, and `pm_exec()` — owned by this package.
+2. A one-line `savvy-commit` section that runs the commitlint check:
+
+```sh
+in_ci || pm_exec commitlint --config "$ROOT/<path>" --edit "$1"
+```
+
+The package-manager runner is now standardized on local exec semantics
+for all four supported PMs (`pnpm exec` / `yarn exec` / `bun x` /
+`npx --no`), fixing the previous `yarn dlx` / `bun x` inconsistency.
+
+Users may inject custom shell above, below, or between the sections.
+Existing hooks are updated in place; unmanaged content is preserved.
+
+### `savvy-commit init`: hygiene hooks in `post-checkout` and `post-merge`
+
+`savvy-commit init` now writes a `savvy-hooks` section into
+`.husky/post-checkout` and `.husky/post-merge`. This section ensures
+tracked `.sh` files stay executable across platforms:
+
+```sh
+git config core.fileMode false
+find . -name "*.sh" -not -path "./.git/*" | xargs chmod +x 2>/dev/null || true
+```
+
+The write is self-guarded and idempotent — running `init` twice or
+alongside another package that writes the same section produces no diff.
+
+The `--force` flag now only resets `.husky/commit-msg` and the config
+file; the hygiene hooks are never force-reset.
+
+### `savvy-commit check`: per-section validation
+
+`savvy-commit check` now validates the `savvy-base`, `savvy-commit`, and
+`savvy-hooks` sections (in both hygiene hooks) independently, reporting
+per-section health for each. The final "configured correctly" verdict
+now factors in section staleness in addition to file existence.
+
+## Breaking Changes
+
+The options schema for `CommitlintConfig.silk(options)` has migrated from
+`zod` to Effect Schema. The accepted input shape and all defaults are
+unchanged. However, if your code catches the validation error thrown on
+invalid options by type, the error is now an Effect Schema `ParseError`
+rather than a `ZodError`:
+
+```ts
+// Before
+import { ZodError } from "zod";
+try {
+  CommitlintConfig.silk(badOptions);
+} catch (e) {
+  if (e instanceof ZodError) { /* ... */ }
+}
+
+// After — Effect Schema ParseError
+import { ParseError } from "@effect/schema/ParseResult";
+try {
+  CommitlintConfig.silk(badOptions);
+} catch (e) {
+  if (e instanceof ParseError) { /* ... */ }
+}
+```
+
+`zod` is no longer a runtime dependency of this package.

--- a/.changeset/fancy-bears-swim.md
+++ b/.changeset/fancy-bears-swim.md
@@ -32,7 +32,7 @@ tracked `.sh` files stay executable across platforms:
 
 ```sh
 git config core.fileMode false
-find . -name "*.sh" -not -path "./.git/*" | xargs chmod +x 2>/dev/null || true
+git ls-files -z '*.sh' | xargs -0 chmod +x 2>/dev/null || true
 ```
 
 The write is self-guarded and idempotent — running `init` twice or
@@ -66,11 +66,12 @@ try {
 }
 
 // After — Effect Schema ParseError
-import { ParseError } from "@effect/schema/ParseResult";
+import { ParseResult } from "effect";
+
 try {
   CommitlintConfig.silk(badOptions);
 } catch (e) {
-  if (e instanceof ParseError) { /* ... */ }
+  if (e instanceof ParseResult.ParseError) { /* ... */ }
 }
 ```
 

--- a/.claude/design/commitlint/overview.md
+++ b/.claude/design/commitlint/overview.md
@@ -3,8 +3,8 @@ status: current
 module: commitlint
 category: architecture
 created: 2026-02-02
-updated: 2026-05-11
-last-synced: 2026-05-11
+updated: 2026-05-27
+last-synced: 2026-05-27
 completeness: 92
 related: []
 dependencies:
@@ -13,7 +13,6 @@ dependencies:
   - "@effect/cli"
   - "@effect/platform-node"
   - effect
-  - zod
   - shell-quote
 implementation-plans:
   - ../plans/wondrous-purring-bee.md
@@ -44,8 +43,8 @@ auto-detection of DCO requirements, workspace scopes, and versioning strategies.
 14. [Related Documentation](#related-documentation)
 
 Note: The Custom Plugin System and Factory Implementation are subsections of
-the Dynamic Configuration API section. The Hook Subcommand Tree is a
-subsection of CLI Tool.
+the Dynamic Configuration API section. The Shared Managed-Section Model, Init
+Command, Check Command and Hook Subcommand Tree are subsections of CLI Tool.
 
 ---
 
@@ -63,7 +62,7 @@ repositories.
 - **Single Package**: Config, prompt, formatter, and CLI in one package
 - **Peer Dependencies**: Commitlint packages as peers for version flexibility
 - **Convention over Configuration**: Sensible defaults with easy overrides
-- **Zod Validation**: Type-safe configuration with rich error messages
+- **Effect Schema Validation**: Type-safe configuration with rich error messages
 
 **When to reference this document:**
 
@@ -120,8 +119,12 @@ services provided by `@savvy-web/silk-effects` and `workspaces-effect`:
 - **DCO detection**: Remains synchronous. Replaced `findProjectRoot` from
   `workspace-tools` with an inlined implementation that walks up the directory
   tree looking for root markers (`pnpm-workspace.yaml`, `.git`, `package.json`).
-- **Managed sections**: `init.ts` and `check.ts` use `ManagedSection` service
-  from `@savvy-web/silk-effects` instead of manual BEGIN/END marker parsing.
+- **Managed sections**: `init.ts` and `check.ts` use the `ManagedSection` service
+  from `@savvy-web/silk-effects` instead of manual BEGIN/END marker parsing. As of
+  silk-effects `^0.5.0`, `init` writes ordered shared sections (`savvy-base` preamble
+  plus the one-line `savvy-commit` tool section) via `ManagedSection.syncMany`, and a
+  co-owned `savvy-hooks` hygiene section into `.husky/post-checkout` / `.husky/post-merge`
+  via `ManagedSection.sync` (see "Init Command" and "Shared Managed-Section Model").
 - **Deleted files**: `package/src/detection/versioning.ts`, `package/src/detection/versioning.test.ts`,
   `package/src/detection/utils.ts`
 
@@ -186,18 +189,21 @@ export default CommitlintConfig.silk({
    changeset config for release format
 4. **Zero Config**: Works out of the box for most repositories
 
-### Zod for Configuration Validation
+### Effect Schema for Configuration Validation
 
 **Context:** How to validate and type configuration?
 
-**Decision:** Use Zod schemas for all configuration objects
+**Decision:** Use Effect `Schema` for all configuration objects. The package
+migrated off `zod` to `Schema` so it depends on a single validation library
+(Effect is already a direct dependency for the CLI and detection services), and
+`zod` was dropped from dependencies entirely.
 
 **Reasoning:**
 
-1. **Type Safety**: Full TypeScript inference from schemas
-2. **Validation**: Rich error messages for invalid configs
-3. **Schema Export**: Can generate JSON Schema for documentation
-4. **Formatter Integration**: Use schema info for better error explanations
+1. **Single ecosystem**: One validation library across the package, no zod alongside Effect
+2. **Type Safety**: Full TypeScript inference via `Schema.Schema.Type`
+3. **Validation**: `Schema.decodeUnknownSync` throws a `ParseError` with a structured message, mirroring the previous zod `.parse()` contract
+4. **Defaults**: `Schema.optionalWith(..., { default })` applies defaults during decode
 
 ### Custom Formatter
 
@@ -259,7 +265,7 @@ package/
     config/
       factory.ts                  # createConfig() implementation
       factory.test.ts             # Factory unit tests
-      schema.ts                   # Zod schemas + ConfigOptions interface
+      schema.ts                   # Effect Schema + ConfigOptions interface + decodeConfigOptions
       types.ts                    # TypeScript type definitions
       rules.ts                    # Rule definitions and defaults
       plugins.ts                  # Custom commitlint plugin (silk/ rules)
@@ -292,10 +298,10 @@ package/
       index.ts                    # Effect CLI entry (runCli, exports)
       index.test.ts               # CLI integration tests
       commands/
-        constants.ts              # Shared constants (CHECK_MARK, WARNING, paths)
-        init.ts                   # Bootstrap husky hooks (managed section)
+        constants.ts              # Shared constants (CHECK_MARK, WARNING, commit-msg + post-checkout + post-merge paths)
+        init.ts                   # Bootstrap husky hooks (savvy-base + savvy-commit + savvy-hooks sections)
         init.test.ts              # Init command tests
-        check.ts                  # Validate current setup + managed status
+        check.ts                  # Validate current setup + per-section health
         check.test.ts             # Check command tests
         hook.ts                   # `hook` parent command (internal)
         hook.test.ts              # Parent-command tests
@@ -411,14 +417,14 @@ namespace for configuration creation.
 // package/src/index.ts
 import { createConfig } from "./config/factory.js";
 import type { ConfigOptions } from "./config/schema.js";
-import { ConfigOptionsSchema } from "./config/schema.js";
+import { decodeConfigOptions } from "./config/schema.js";
 import type { CommitlintUserConfig } from "./config/types.js";
 
 export type { CommitlintUserConfig, ConfigOptions };
 
 export class CommitlintConfig {
   static silk(options: ConfigOptions = {}): CommitlintUserConfig {
-    const validated = ConfigOptionsSchema.parse(options);
+    const validated = decodeConfigOptions(options);
     return createConfig(validated);
   }
 
@@ -437,59 +443,45 @@ re-exported from `static.ts`).
 
 ### Configuration Schema
 
-The configuration uses a dual-definition pattern: a Zod schema for runtime
+The configuration uses a dual-definition pattern: an Effect `Schema` for runtime
 validation and a manually-written `ConfigOptions` interface for better JSDoc
-documentation. The interface is the public-facing type; the schema is used
-internally by `CommitlintConfig.silk()` to validate and apply defaults.
+documentation. The interface is the public-facing type; the schema is decoded
+internally by `CommitlintConfig.silk()` (via `decodeConfigOptions`) to validate
+and apply defaults. See `package/src/config/schema.ts` for the full schema and
+interface.
 
 ```typescript
 // package/src/config/schema.ts
-import { z } from "zod";
+import { Schema } from "effect";
 
 export type ReleaseFormat = "semver" | "packages" | "scoped";
-export const ReleaseFormatSchema = z.enum(["semver", "packages", "scoped"]);
+export const ReleaseFormatSchema = Schema.Literal("semver", "packages", "scoped");
 
-// Internal: Zod schema for validation and defaults
-export const ConfigOptionsSchema = z.object({
-  dco: z.boolean().optional(),
-  scopes: z.array(z.string()).optional(),
-  additionalScopes: z.array(z.string()).optional(),
-  releaseFormat: ReleaseFormatSchema.optional(),
-  emojis: z.boolean().default(false),
-  bodyMaxLineLength: z.number().positive().default(300),
-  noMarkdown: z.boolean().default(true),
-  cwd: z.string().optional(),
+// Internal: Effect Schema for validation and defaults
+export const ConfigOptionsSchema = Schema.Struct({
+  dco: Schema.optional(Schema.Boolean),
+  scopes: Schema.optional(Schema.Array(Schema.String)),
+  additionalScopes: Schema.optional(Schema.Array(Schema.String)),
+  releaseFormat: Schema.optional(ReleaseFormatSchema),
+  emojis: Schema.optionalWith(Schema.Boolean, { default: () => false }),
+  bodyMaxLineLength: Schema.optionalWith(Schema.Number.pipe(Schema.positive()), { default: () => 300 }),
+  noMarkdown: Schema.optionalWith(Schema.Boolean, { default: () => true }),
+  cwd: Schema.optional(Schema.String),
 });
 
-// Public: manually-written interface with rich JSDoc
-export interface ConfigOptions {
-  /** Enable DCO signoff requirement (auto-detected from DCO file if omitted) */
-  dco?: boolean;
-  /** Allowed scopes (replaces auto-detected when provided) */
-  scopes?: string[];
-  /** Additional scopes to merge with auto-detected */
-  additionalScopes?: string[];
-  /** Release commit format (auto-detected from versioning strategy if omitted) */
-  releaseFormat?: ReleaseFormat;
-  /** Enable emojis in prompt configuration @defaultValue false */
-  emojis?: boolean;
-  /** Maximum body line length @defaultValue 300 */
-  bodyMaxLineLength?: number;
-  /** Reject markdown formatting in commit messages @defaultValue true */
-  noMarkdown?: boolean;
-  /** Working directory for auto-detection @defaultValue process.cwd() */
-  cwd?: string;
-}
+// Synchronous decoder used by CommitlintConfig.silk(); throws ParseError on bad input
+export const decodeConfigOptions = Schema.decodeUnknownSync(ConfigOptionsSchema);
 
-// Resolved type after Zod parsing applies defaults (internal)
-export type ResolvedConfigOptions = z.output<typeof ConfigOptionsSchema>;
+// Resolved type after decoding applies defaults (internal)
+export type ResolvedConfigOptions = Schema.Schema.Type<typeof ConfigOptionsSchema>;
 ```
 
-The `ConfigOptions` interface is manually written rather than inferred from the
-Zod schema (`z.input<typeof ConfigOptionsSchema>`) to provide richer JSDoc
-documentation including `@remarks`, `@defaultValue`, and `@example` tags that
-Zod schemas cannot express. The Zod schema and interface are kept in sync
-manually.
+The `ConfigOptions` interface (not shown) is manually written rather than
+inferred from the schema so it can carry richer JSDoc — `@remarks`,
+`@defaultValue` and `@example` tags the schema cannot express. The schema and
+interface are kept in sync manually. `decodeConfigOptions` is
+`Schema.decodeUnknownSync(ConfigOptionsSchema)`, throwing a `ParseError` on
+invalid input to preserve the previous zod `.parse()` throw-on-failure contract.
 
 ### Custom Plugin System
 
@@ -863,101 +855,123 @@ export { checkCommand, hookCommand, initCommand, rootCommand };
 | `WorkspaceRootLive` | `WorkspaceRoot` (root directory detection) | `workspaces-effect` |
 | `NodeContext.layer` | `FileSystem`, `Path`, `Terminal` | `@effect/platform-node` |
 
-### Init Command - Managed Section Pattern
+### Shared Managed-Section Model
 
-The init command (`package/src/cli/commands/init.ts`) uses the `ManagedSection` service
-from `@savvy-web/silk-effects` to manage BEGIN/END markers in the husky
-hook. This replaces the previous manual marker parsing with a service-based
-approach. The service handles reading, writing, and updating managed sections
-in files, allowing users to add custom hooks above or below the managed block
-without them being overwritten on updates.
+As of silk-effects `^0.5.0`, the husky hooks are composed from **shared**
+managed sections that both `@savvy-web/commitlint` and its sibling
+`@savvy-web/lint-staged` write idempotently, rather than one combined
+commitlint-owned block. silk-effects owns the section generators; this package
+only chooses which sections go in which hook and what config path the tool
+section pins. There are three section identities:
+
+| Section | Hook(s) | Generator (silk-effects) | Guard | Ownership |
+| :------ | :------ | :----------------------- | :---- | :-------- |
+| `savvy-base` | `.husky/commit-msg` | `SavvyBaseSection` / `savvyBasePreamble()` | unguarded (pure definitions) | shared base |
+| `savvy-commit` | `.husky/commit-msg` | `savvyToolSection("savvy-commit", cmd)` | `in_ci \|\| …` (self-guarded) | this package |
+| `savvy-hooks` | `.husky/post-checkout`, `.husky/post-merge` | `SavvyHooksSection` / `savvyHooksHygiene()` | self-guarded against CI | co-owned with `@savvy-web/lint-staged` |
+
+`savvyBasePreamble()` emits the shared preamble — `ROOT=$(git rev-parse --show-toplevel)`,
+an `in_ci()` helper, `detect_pm()`, `PM=$(detect_pm)` and a `pm_exec()` helper
+standardized on local-exec semantics (`pnpm exec` / `yarn exec` / `bun x` / `npx --no`).
+It runs unguarded so the definitions are always in scope; each side-effecting
+section then guards itself with `in_ci || …`. This is the inversion of the
+earlier single-block design where the whole commitlint block lived behind one
+CI guard.
+
+`savvyToolSection("savvy-commit", cmd)` builds a one-line tool section:
+`in_ci || pm_exec commitlint --config "$ROOT/<path>" --edit "$1"`. The
+`savvy-hooks` hygiene section (`git config core.fileMode false` plus chmod of
+tracked `.sh` files, self-guarded against CI) was previously owned by
+`@savvy-web/lint-staged`; it is now a shared base concern both packages may
+write without conflict.
+
+### Init Command
+
+The init command (`package/src/cli/commands/init.ts`) writes the shared sections
+above into the husky hooks via the `ManagedSection` service. See the file for the
+exact orchestration; the load-bearing pieces:
 
 **Options:**
 
-- `--force` / `-f`: Overwrite the entire hook file, not just the managed section
+- `--force` / `-f`: Overwrite the `.husky/commit-msg` file (header + a fresh
+  re-sync of its sections). The hygiene sections in `post-checkout` / `post-merge`
+  are never force-reset — they are always `sync`'d idempotently.
 - `--config` / `-c`: Relative path for the commitlint config file (default:
-  `lib/configs/commitlint.config.ts`)
+  `lib/configs/commitlint.config.ts`). Must be relative to the repo root.
 
-**Key Functions:**
+**Key exports (consumed by the check command and tests):**
 
-| Function | Purpose |
-| :------- | :------ |
-| `generateManagedContent(configPath)` | Returns the inner content between markers. Includes package manager detection, CI skip guard, and commitlint invocation. |
-| `writeFullHook(path, configPath)` | Writes a fresh hook file with shebang header, then delegates to `ManagedSection.write()` for the managed block. |
+| Export | Purpose |
+| :----- | :------ |
+| `SECTION_DEF` | `SectionDefinition.make({ toolName: "savvy-commit" })` — the identity used to read/check/remove the tool section. |
+| `savvyCommitBlock(configPath)` | Returns the `savvy-commit` `SectionBlock` for a config path. Check rebuilds this to compare against the on-disk section. |
+| `generateManagedContent(configPath)` | `savvyCommitBlock(configPath).content` — retained for the check command and tests. |
 
 **ManagedSection service usage:**
 
-- `SectionDefinition.make({ toolName })` - Create a section definition
-- `sectionDef.block(content)` - Create a block with content for the section
-- `ms.sync(path, block)` - Sync managed section (creates, updates, or reports unchanged)
-- `ms.write(path, block)` - Write/overwrite managed section in a file
+- `ms.syncMany(path, blocks[])` — sync an **ordered** list of sections in one
+  pass, preserving user content above, below and between them. Used for
+  `.husky/commit-msg`: `[SavvyBaseSection.block(savvyBasePreamble()), savvyCommitBlock(config)]`.
+- `ms.sync(path, block)` — sync a single section. Used for the `savvy-hooks`
+  hygiene section in `post-checkout` / `post-merge`.
+- `ms.check(path, block)` / `ms.read(path, def)` — used by the check command (below).
+- `ms.remove(path, def)` — also available from the `^0.5.0` API for tearing a
+  section back out.
 
-The `extractManagedSection` and `updateManagedSection` functions from the
-previous implementation have been removed; their logic is now encapsulated
-in the `ManagedSection` service.
+`init` ensures each hook file exists (writing a shebang header if absent), runs
+the relevant sync, then `chmod`s the file executable. The commit-msg sync logs
+the per-section tagged results (`Created` / `Updated` / `Unchanged`). It also
+creates the commitlint config file, respecting `--config` and creating parent
+directories as needed.
 
-**CI Skip Guard:**
+Users may add custom commands above, below, or between the managed sections;
+the markers are preserved across re-runs.
 
-The managed section uses an `if ! { ... }; then ... fi` pattern instead of
-`exit 0` so that user code outside the managed block still runs even in CI:
+### Check Command - Per-Section Health
 
-```bash
-if ! { [ -n "$CI" ] || [ -n "$GITHUB_ACTIONS" ]; }; then
-  # ... commitlint invocation ...
-fi
-```
-
-**Three-Branch Hook Handling:**
-
-1. **Exists + no force**: Sync managed section via `ms.sync()` which returns
-   a tagged result (`Updated`, `Created`, or `Unchanged`). Preserves user
-   code above/below the markers.
-2. **Exists + force**: Overwrite the entire file with
-   `generateFullHookContent()`. Logs "Replaced (--force)".
-3. **New file**: Create `.husky/` directory and write fresh hook with
-   `generateFullHookContent()`. Logs "Created".
-
-The command also handles the commitlint config file creation, respecting the
-`--config` path option and creating parent directories as needed.
-
-### Check Command - Managed Section Status
-
-The check command (`package/src/cli/commands/check.ts`) validates the current commitlint
-setup and reports detected settings, including managed section status. It uses
-`CheckResult`, `ManagedSection`, and `VersioningStrategy` from
-`@savvy-web/silk-effects`.
-
-**Service dependencies:**
-
-```typescript
-import { CheckResult, ManagedSection, VersioningStrategy } from "@savvy-web/silk-effects";
-import { WorkspaceDiscovery } from "workspaces-effect";
-```
+The check command (`package/src/cli/commands/check.ts`) validates the current
+commitlint setup, reports detected settings, and checks each shared managed
+section independently. It uses `CheckResult`, `ManagedSection`,
+`VersioningStrategy` plus the shared section generators
+(`SavvyBaseSection` / `savvyBasePreamble`, `SavvyHooksSection` /
+`savvyHooksHygiene`) from `@savvy-web/silk-effects`, and `WorkspaceDiscovery`
+from `workspaces-effect`.
 
 **Key Functions:**
 
 | Function | Purpose |
 | :------- | :------ |
-| `findConfigFile(fs)` | Searches for commitlint config across 16 possible file names in priority order. |
-| `extractConfigPathFromManaged(managedContent)` | Extracts the config path from the `commitlint --config "$ROOT/{path}"` pattern in the managed section. |
-| `checkManagedSectionStatus(existingManaged)` | Compares the current managed section against what would be generated to determine if it is up-to-date. |
-| `detectReleaseFormat` | Effect that uses `VersioningStrategy` and `WorkspaceDiscovery` services to detect the release format. |
+| `findConfigFile(fs)` | Searches for the commitlint config across the `CONFIG_FILES` list in priority order. |
+| `extractConfigPathFromManaged(managedContent)` | Extracts the config path from the `commitlint --config "$ROOT/{path}"` pattern, so the rebuilt `savvy-commit` block compares against whatever path is actually pinned. |
+| `detectReleaseFormat` | Effect that uses `VersioningStrategy` and `WorkspaceDiscovery` to detect the release format. |
 
-**Managed Section Status Reporting:**
+**Section health, factored into the verdict:**
 
-The check command reports one of three states for the managed section:
+`check` evaluates each section via `ms.check(path, block)`, treating only
+`CheckResult.Found` with `isUpToDate` as healthy. A single `sectionsHealthy`
+flag accumulates across all sections:
 
-- **Up-to-date**: Managed section matches what `generateManagedContent()` would
-  produce (with whitespace normalization for comparison).
-- **Outdated**: Managed section exists but content has drifted. Suggests running
-  `savvy-commit init` to update.
-- **Not found**: No managed section markers detected. Suggests running
-  `savvy-commit init` to add one.
+- **`savvy-base`** (in `.husky/commit-msg`): checked against
+  `SavvyBaseSection.block(savvyBasePreamble())`.
+- **`savvy-commit`** (in `.husky/commit-msg`): the tool section is `read` first
+  to recover its pinned config path, then `check`ed against
+  `savvyCommitBlock(configPath)`. Missing path or missing section both count as
+  unhealthy.
+- **`savvy-hooks`** (in `.husky/post-checkout` and `.husky/post-merge`): each
+  hygiene hook is checked for existence and against
+  `SavvyHooksSection.block(savvyHooksHygiene())`.
+
+Each section reports up-to-date / outdated / not-found. The final verdict is now
+`!foundConfig || !hasHuskyHook || !sectionsHealthy` — i.e. a stale or missing
+section in **any** of the three hooks makes `check` report "needs configuration",
+whereas the earlier verdict only checked config-file and commit-msg-hook
+existence.
 
 **Additional Checks:**
 
-- Config file presence (searches 16 possible filenames)
-- Husky hook presence
+- Config file presence (searches the `CONFIG_FILES` list)
+- Husky commit-msg hook presence
+- Hygiene hook (`post-checkout` / `post-merge`) presence and section freshness
 - DCO file presence
 - Detected settings (DCO, release format, scopes)
 
@@ -1325,10 +1339,9 @@ Users who prefer `@commitlint/cz-commitlint` can install it separately.
 ```json
 {
   "dependencies": {
-    "@savvy-web/silk-effects": "^0.2.2",
-    "workspaces-effect": "^0.3.0",
-    "shell-quote": "^1.8.3",
-    "zod": "^4.3.6"
+    "@savvy-web/silk-effects": "^0.5.0",
+    "workspaces-effect": "^1.1.0",
+    "shell-quote": "^1.8.4"
   }
 }
 ```
@@ -1338,6 +1351,19 @@ by `workspaces-effect` (for workspace/scope discovery) and
 `@savvy-web/silk-effects` (for managed sections and versioning strategy).
 `shell-quote` was added in 0.7.0 to tokenize Bash command strings inside the
 `hook` subcommand tree's commit-message parser.
+
+`zod` has been removed: config validation migrated to Effect `Schema` (see
+"Effect Schema for Configuration Validation"), so the package no longer carries
+a second validation library alongside Effect.
+
+silk-effects `^0.5.0` adds the shared managed-section API consumed by `init`
+and `check`: `ManagedSection.syncMany` / `ManagedSection.remove`, the section
+generators `SavvyBaseSection` / `savvyBasePreamble`, `SavvyHooksSection` /
+`savvyHooksHygiene`, and `savvyToolSection` (see "Shared Managed-Section Model").
+
+workspaces-effect `^1.1.0` adds a `refresh()` method to the `WorkspaceDiscovery`
+service; test stubs of the service therefore implement
+`refresh: () => Effect.void` alongside the existing methods.
 
 ### CLI Dependencies (bundled via Effect catalog)
 
@@ -1400,23 +1426,26 @@ export { default } from "@savvy-web/commitlint/static";
 
 ### Husky Integration
 
-Run `savvy-commit init` to generate `.husky/commit-msg` with a managed section.
-The generated hook auto-detects the package manager and uses the correct
-`dlx`/`npx` equivalent. Users can add custom hooks above or below the managed
-section markers without them being overwritten on subsequent `init` runs.
+Run `savvy-commit init` to generate the husky hooks with shared managed sections.
+`.husky/commit-msg` gets the `savvy-base` preamble (package-manager detection plus
+`in_ci` / `pm_exec` helpers) followed by the one-line `savvy-commit` tool section
+that invokes commitlint. `.husky/post-checkout` and `.husky/post-merge` get the
+co-owned `savvy-hooks` hygiene section. Users can add custom hooks above, below,
+or between the markers without them being overwritten on subsequent `init` runs.
 
 ```bash
 #!/usr/bin/env sh
-# Custom hooks can go here (above managed section)
+# Custom hooks can go here (above the managed sections)
+
+# --- BEGIN SAVVY-BASE MANAGED SECTION ---
+# ROOT, in_ci(), detect_pm(), PM, pm_exec() — shared preamble, runs unguarded
+# --- END SAVVY-BASE MANAGED SECTION ---
 
 # --- BEGIN SAVVY-COMMIT MANAGED SECTION ---
-# DO NOT EDIT between these markers - managed by savvy-commit
-if ! { [ -n "$CI" ] || [ -n "$GITHUB_ACTIONS" ]; }; then
-  # ... package manager detection and commitlint invocation ...
-fi
+in_ci || pm_exec commitlint --config "$ROOT/lib/configs/commitlint.config.ts" --edit "$1"
 # --- END SAVVY-COMMIT MANAGED SECTION ---
 
-# Custom hooks can go here (below managed section)
+# Custom hooks can go here (below the managed sections)
 ```
 
 ### Formatter Configuration
@@ -1717,7 +1746,10 @@ describe("commitlint integration", () => {
 
 **Document Status:** Current - Core implementation complete, CLI implemented,
 migrated to silk-effects, plugin hook architecture extended (Phase 8), `tdd`
-commit type and `silk/tdd-scope` rule added (feat/tdd branch).
+commit type and `silk/tdd-scope` rule added (feat/tdd branch), husky hooks
+split into shared `savvy-base` + `savvy-commit` + co-owned `savvy-hooks` hygiene
+sections via silk-effects `^0.5.0` `syncMany`, config validation migrated from
+zod to Effect Schema, workspaces-effect bumped to `^1.1.0`.
 
 **Completed:**
 
@@ -1756,6 +1788,17 @@ commit type and `silk/tdd-scope` rule added (feat/tdd branch).
     redirects to absolute / home-dir / traversal paths~~
 24. ~~Update `session-start` quality block: no artificial line breaks,
     2-5 line body max, `<skip_in_body>` noise-exclusion list~~
+25. ~~Split `.husky/commit-msg` into shared `savvy-base` preamble + one-line
+    `savvy-commit` tool section via silk-effects `^0.5.0` `syncMany`; co-own
+    `savvy-hooks` hygiene in `.husky/post-checkout` / `.husky/post-merge` with
+    `@savvy-web/lint-staged`~~
+26. ~~Factor per-section health (`savvy-base` / `savvy-commit` / `savvy-hooks`)
+    into `savvy-commit check`'s "configured correctly" verdict~~
+27. ~~Migrate `package/src/config/schema.ts` off zod to Effect `Schema`; expose
+    synchronous `decodeConfigOptions` from `CommitlintConfig.silk()`; drop
+    `zod` dependency~~
+28. ~~Bump `workspaces-effect` to `^1.1.0` (new `WorkspaceDiscovery.refresh()`
+    method, reflected in test stubs)~~
 
 **Next Steps:**
 

--- a/.github/workflows/pnpm-update.yml
+++ b/.github/workflows/pnpm-update.yml
@@ -62,8 +62,8 @@ jobs:
             @savvy-web/silk-effects
             commitizen
             husky
-            workspace-effect
-            zod
+            shell-quote
+            workspaces-effect
           peer-lock: |
             @commitlint/cli
             @commitlint/config-conventional

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,46 +1,34 @@
 #!/usr/bin/env sh
-# Commit-msg hook with savvy-commit managed section
-# Custom hooks can go above or below the managed section
+# Commit-msg hook with savvy managed sections
+# Custom hooks can go above, below, or between the managed sections
 
-# --- BEGIN SAVVY-COMMIT MANAGED SECTION ---
-# DO NOT EDIT between these markers - managed by savvy-commit
-# Skip managed section in CI environment
-if ! { [ -n "$CI" ] || [ -n "$GITHUB_ACTIONS" ]; }; then
-
-# Get repo root directory
+# --- BEGIN SAVVY-BASE MANAGED SECTION ---
 ROOT=$(git rev-parse --show-toplevel)
 
-# Detect package manager from package.json or lockfiles
+in_ci() { [ -n "$CI" ] || [ -n "$GITHUB_ACTIONS" ]; }
+
 detect_pm() {
-  # Check packageManager field in package.json (e.g., "pnpm@9.0.0")
   if [ -f "$ROOT/package.json" ]; then
     pm=$(jq -r '.packageManager // empty' "$ROOT/package.json" 2>/dev/null | cut -d'@' -f1)
-    if [ -n "$pm" ]; then
-      echo "$pm"
-      return
-    fi
+    if [ -n "$pm" ]; then echo "$pm"; return; fi
   fi
-
-  # Fallback to lockfile detection
-  if [ -f "$ROOT/pnpm-lock.yaml" ]; then
-    echo "pnpm"
-  elif [ -f "$ROOT/yarn.lock" ]; then
-    echo "yarn"
-  elif [ -f "$ROOT/bun.lock" ]; then
-    echo "bun"
-  else
-    echo "npm"
-  fi
+  if   [ -f "$ROOT/pnpm-lock.yaml" ]; then echo "pnpm"
+  elif [ -f "$ROOT/yarn.lock" ];      then echo "yarn"
+  elif [ -f "$ROOT/bun.lock" ];       then echo "bun"
+  else echo "npm"; fi
 }
-
-# Run commitlint via the detected package manager
 PM=$(detect_pm)
-case "$PM" in
-  pnpm) pnpm exec commitlint --config "$ROOT/lib/configs/commitlint.config.ts" --edit "$1" ;;
-  yarn) yarn dlx commitlint --config "$ROOT/lib/configs/commitlint.config.ts" --edit "$1" ;;
-  bun)  bun x commitlint --config "$ROOT/lib/configs/commitlint.config.ts" --edit "$1" ;;
-  *)    npx --no -- commitlint --config "$ROOT/lib/configs/commitlint.config.ts" --edit "$1" ;;
-esac
 
-fi
+pm_exec() {
+  case "$PM" in
+    pnpm) pnpm exec "$@" ;;
+    yarn) yarn exec "$@" ;;
+    bun)  bun x "$@" ;;
+    *)    npx --no -- "$@" ;;
+  esac
+}
+# --- END SAVVY-BASE MANAGED SECTION ---
+
+# --- BEGIN SAVVY-COMMIT MANAGED SECTION ---
+in_ci || pm_exec commitlint --config "$ROOT/lib/configs/commitlint.config.ts" --edit "$1"
 # --- END SAVVY-COMMIT MANAGED SECTION ---

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,17 +1,10 @@
 #!/usr/bin/env sh
-# Post-checkout hook with savvy-lint managed section
+# Managed by savvy-hooks
 # Custom hooks can go above or below the managed section
 
-# --- BEGIN SAVVY-LINT MANAGED SECTION ---
-# DO NOT EDIT between these markers - managed by savvy-lint
+# --- BEGIN SAVVY-HOOKS MANAGED SECTION ---
 if ! { [ -n "$CI" ] || [ -n "$GITHUB_ACTIONS" ]; }; then
-
-# Configure git to ignore executable bit changes
-# This ensures hook scripts can be made executable locally without git tracking the change
-git config core.fileMode false
-
-# Ensure all shell scripts tracked by git are executable
-git ls-files -z '*.sh' | xargs -0 -r chmod +x 2>/dev/null || true
-
+  git config core.fileMode false
+  git ls-files -z '*.sh' | xargs -0 chmod +x 2>/dev/null || true
 fi
-# --- END SAVVY-LINT MANAGED SECTION ---
+# --- END SAVVY-HOOKS MANAGED SECTION ---

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,17 +1,10 @@
 #!/usr/bin/env sh
-# Post-merge hook with savvy-lint managed section
+# Managed by savvy-hooks
 # Custom hooks can go above or below the managed section
 
-# --- BEGIN SAVVY-LINT MANAGED SECTION ---
-# DO NOT EDIT between these markers - managed by savvy-lint
+# --- BEGIN SAVVY-HOOKS MANAGED SECTION ---
 if ! { [ -n "$CI" ] || [ -n "$GITHUB_ACTIONS" ]; }; then
-
-# Configure git to ignore executable bit changes
-# This ensures hook scripts can be made executable locally without git tracking the change
-git config core.fileMode false
-
-# Ensure all shell scripts tracked by git are executable
-git ls-files -z '*.sh' | xargs -0 -r chmod +x 2>/dev/null || true
-
+  git config core.fileMode false
+  git ls-files -z '*.sh' | xargs -0 chmod +x 2>/dev/null || true
 fi
-# --- END SAVVY-LINT MANAGED SECTION ---
+# --- END SAVVY-HOOKS MANAGED SECTION ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,9 +37,11 @@ pnpm ci:build              # CI-mode full rebuild — updates the live workspace
 The commitlint CLI is available immediately after rebuild:
 
 ```bash
-pnpm exec savvy-commit check   # show detected config (not a message linter)
+pnpm exec savvy-commit check   # validate config, husky hooks, and managed-section health (not a message linter)
 pnpm exec commitlint --config lib/configs/commitlint.config.ts --edit <file>  # lint a message
 ```
+
+`savvy-commit init` writes three husky hooks via silk-effects managed sections: `.husky/commit-msg` (ordered `savvy-base` preamble + `savvy-commit` tool section) and the co-owned `savvy-hooks` hygiene section in both `.husky/post-checkout` and `.husky/post-merge`. `savvy-commit check` reports all three section identities and factors section health into its verdict.
 
 The git commit-msg hook also runs the live build — `git commit --allow-empty -m "..."` exercises
 the full hook pipeline.
@@ -105,12 +107,20 @@ bats plugin/hooks/__test__/match-safe-bash.bats
 - `index.ts`, `static.ts` — public entry points (`CommitlintConfig.silk()`
   and the static config).
 - `config/`, `detection/`, `prompt/`, `formatter/` — config factory and the
-  pieces consumers wire up.
-- `cli/` — `@effect/cli` command tree. `commands/init.ts` and
-  `commands/check.ts` are the user-facing commands; `commands/hook.ts`
-  parents the **internal** `savvy-commit hook` subcommand tree under
-  `commands/hooks/` (`session-start`, `pre-commit-message`,
-  `post-commit-verify`, `user-prompt-submit`).
+  pieces consumers wire up. `config/schema.ts` validates `ConfigOptions`
+  with **Effect Schema** (`decodeConfigOptions`); zod is no longer a
+  dependency.
+- `cli/` — `@effect/cli` command tree. User-facing commands live in
+  `commands/init.ts` (writes `.husky/commit-msg` as ordered `savvy-base` +
+  `savvy-commit` managed sections via `ManagedSection.syncMany`, plus the
+  co-owned `savvy-hooks` hygiene section in `.husky/post-checkout` and
+  `.husky/post-merge`) and `commands/check.ts` (validates config presence,
+  husky hook presence, and all three managed-section identities, factoring
+  section health into the verdict). `commands/constants.ts` holds the
+  three husky hook paths. `commands/hook.ts` parents the **internal**
+  `savvy-commit hook` subcommand tree under `commands/hooks/`
+  (`session-start`, `pre-commit-message`, `post-commit-verify`,
+  `user-prompt-submit`).
 - `hook/` — helpers shared by hook subcommands: Effect Schemas for the four
   hook envelopes (`envelope.ts`), JSON output builders (`output.ts`), the
   shell-quote-based `parse-bash-command.ts`, the `HookSilencer` Layer
@@ -166,9 +176,13 @@ Turbo: `typecheck` depends on `build` completing first.
 - **Biome**: Unified linting and formatting (replaces ESLint + Prettier).
 - **Commitlint**: Enforces conventional commits with DCO signoff (this repo
   dogfoods its own package).
-- **Husky Hooks**:
+- **Husky Hooks** (managed via silk-effects `ManagedSection`):
   - `pre-commit`: Runs lint-staged.
-  - `commit-msg`: Validates commit message format.
+  - `commit-msg`: `savvy-base` preamble (`ROOT`, `in_ci`, `pm_exec`) +
+    `savvy-commit` tool section that runs `commitlint --edit "$1"`.
+  - `post-checkout` / `post-merge`: Co-owned `savvy-hooks` hygiene section
+    (`git config core.fileMode false` + chmod of tracked `.sh`). Shared
+    with `@savvy-web/lint-staged`; both packages write it idempotently.
   - `pre-push`: Runs tests for affected packages.
 
 ### TypeScript Configuration

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Commitlint configuration that reads your repository at load time — checking fo
 
 - **Auto-detection** — scans for a `DCO` file, workspace packages and changeset config; no manual flags required
 - **Zero config** — `CommitlintConfig.silk()` picks the right rules; no flags needed
-- **Type-safe** — ships full TypeScript types; Zod validates every detected value at load time
+- **Type-safe** — ships full TypeScript types; Effect Schema validates every option at load time
 - **Extended types** — adds `ai`, `release` and `tdd` commit types on top of the conventional-commits baseline
 - **Interactive prompts** — includes a commitizen adapter with emoji support
 - **`savvy-commit` CLI** — initializes config and reports detected settings with a single command
@@ -23,7 +23,7 @@ This is a monorepo containing two packages:
 
 | Directory | Description |
 | --- | --- |
-| [`package/`](./package/) | The `@savvy-web/commitlint` npm package: config factory, interactive prompt, Zod detection and the `savvy-commit` CLI. |
+| [`package/`](./package/) | The `@savvy-web/commitlint` npm package: config factory, interactive prompt, repo auto-detection and the `savvy-commit` CLI. |
 | [`plugin/`](./plugin/) | A Claude Code sidecar that registers `SessionStart`, `PreToolUse`, `PostToolUse` and `UserPromptSubmit` hooks — injects branch and signing context, auto-allows safe Bash and curated MCP operations, and replays commitlint plus signing checks after each commit. |
 
 ## Quick start

--- a/docs/01-configuration.md
+++ b/docs/01-configuration.md
@@ -191,4 +191,4 @@ The configuration generates these commitlint rules:
 
 ## Validation
 
-Options are validated with Zod schemas. Invalid options throw at configuration time, before any commit is linted.
+Options are validated with Effect Schema. Invalid options throw a `ParseError` at configuration time, before any commit is linted.

--- a/docs/03-cli.md
+++ b/docs/03-cli.md
@@ -1,6 +1,6 @@
 # CLI reference
 
-`@savvy-web/commitlint` ships a CLI called `savvy-commit` for writing the commitlint config and the husky hook.
+`@savvy-web/commitlint` ships a CLI called `savvy-commit` for writing the commitlint config and the husky hooks it relies on.
 
 ## Install
 
@@ -14,7 +14,7 @@ npm install -D @savvy-web/commitlint @commitlint/cli @commitlint/config-conventi
 
 ### savvy-commit init
 
-Write the commitlint config and the `.husky/commit-msg` hook.
+Write the commitlint config file and three husky hooks: `commit-msg`, `post-checkout` and `post-merge`.
 
 ```bash
 npx savvy-commit init
@@ -25,19 +25,41 @@ npx savvy-commit init
 
 | Option | Alias | Description |
 | ------ | ----- | ----------- |
-| `--force` | `-f` | Overwrite entire hook file (not just managed section) |
+| `--force` | `-f` | Overwrite the commit-msg hook file and config file entirely (hygiene sections in post-checkout/post-merge are never force-reset) |
 | `--config` | `-c` | Relative path for the commitlint config file (default: `lib/configs/commitlint.config.ts`) |
 
 **Generated files:**
 
 - Commitlint config at the specified path (default `lib/configs/commitlint.config.ts`)
-- `.husky/commit-msg` — git hook with a managed section
+- `.husky/commit-msg` — savvy-base preamble followed by a one-line savvy-commit tool section
+- `.husky/post-checkout` and `.husky/post-merge` — savvy-hooks hygiene section (co-owned with `@savvy-web/lint-staged`; both packages write identical content)
 
-**Managed section:**
+**Managed sections:**
 
-The hook uses `BEGIN`/`END` markers to define a managed section. You can add custom hooks above or below the managed block. Re-running `init` updates only the managed section and leaves the rest of the file alone. Use `--force` to replace the entire file.
+Each hook file is split into named sections delimited by `# --- BEGIN SAVVY-<NAME> MANAGED SECTION ---` and `# --- END SAVVY-<NAME> MANAGED SECTION ---` markers. The section identities written by `savvy-commit init` are:
 
-In CI environments (`CI` or `GITHUB_ACTIONS` set), the managed section is skipped so custom hooks outside the markers still execute.
+| Section | File | Purpose |
+| ------- | ---- | ------- |
+| `savvy-base` | `.husky/commit-msg` | Shared preamble: `ROOT`, `in_ci()`, `detect_pm()`, `PM`, `pm_exec()` |
+| `savvy-commit` | `.husky/commit-msg` | One-line tool invocation: `in_ci \|\| pm_exec commitlint --config "$ROOT/<path>" --edit "$1"` |
+| `savvy-hooks` | `.husky/post-checkout`, `.husky/post-merge` | File-mode hygiene: `git config core.fileMode false` and chmod tracked `.sh` files |
+
+You can add custom commands above, below or between the managed sections in any of these files. Re-running `init` updates only the managed sections and leaves the rest alone. Use `--force` to replace the entire commit-msg hook file (the hygiene hooks are never force-reset because they are co-owned with other tools).
+
+The `savvy-base` preamble is side-effect free — it only defines shell functions. The CI guard lives on each tool line (`in_ci || pm_exec ...`), so custom hooks outside the managed sections still run in CI. The hygiene section is self-guarded against CI.
+
+**Package-manager runner:**
+
+The `pm_exec()` helper in the `savvy-base` preamble resolves to the local-exec form for the detected package manager:
+
+| Package manager | Runner |
+| --------------- | ------ |
+| pnpm | `pnpm exec` |
+| yarn | `yarn exec` |
+| bun | `bun x` |
+| npm (fallback) | `npx --no` |
+
+This matches the runner used by sibling packages such as `@savvy-web/lint-staged`, so the same dispatch logic appears in every managed `savvy-base` section.
 
 **Example:**
 
@@ -50,14 +72,14 @@ npx savvy-commit init
 npx savvy-commit init --config commitlint.config.ts
 # example output (varies by environment)
 
-# Force overwrite entire hook file
+# Force overwrite the commit-msg hook file (hygiene hooks unaffected)
 npx savvy-commit init --force
 # example output (varies by environment)
 ```
 
 ### savvy-commit check
 
-Show the current commitlint config and whether the managed section in the hook is up to date.
+Show the current commitlint setup: config file, husky hooks, the health of each managed section and the detected settings the config factory will use.
 
 ```bash
 npx savvy-commit check
@@ -68,18 +90,29 @@ npx savvy-commit check
 ```text
 Checking commitlint configuration...
 
-Config file: commitlint.config.ts
-Husky hook: .husky/commit-msg
-Managed section: up-to-date
-DCO file: DCO
+✓ Config file: commitlint.config.ts
+✓ Husky hook: .husky/commit-msg
+✓ Base section: up-to-date
+✓ Commit section: up-to-date
+✓ Hygiene hook: .husky/post-checkout
+✓ Hygiene hook: .husky/post-merge
+✓ DCO file: DCO
 
 Detected settings:
   DCO required: true
   Release format: semver
   Detected scopes: api, cli, core, docs
+
+✓ Commitlint is configured correctly.
 ```
 
-The managed section status is one of: `up-to-date`, `outdated` (run `savvy-commit init` to update), or `not found`.
+Each section line reports one of three states:
+
+- `up-to-date` — the on-disk content matches what `savvy-commit init` would write
+- `outdated` — the markers are present but the content has drifted; re-run `savvy-commit init` to refresh
+- `not found` — the markers are missing entirely; re-run `savvy-commit init` to add the section
+
+The final verdict is `Commitlint is configured correctly` only when the config file exists, the commit-msg hook exists and every section (`savvy-base`, `savvy-commit`, plus `savvy-hooks` in both hygiene hooks) is up-to-date. Any missing or outdated section flips the verdict to `Commitlint needs configuration. Run: savvy-commit init`.
 
 ## Using with npm scripts
 
@@ -96,7 +129,9 @@ Add to your `package.json`:
 
 ## Husky integration
 
-`savvy-commit init` writes `.husky/commit-msg` with `BEGIN`/`END` markers around the managed section. Custom hooks placed above or below those markers survive re-runs. The managed section detects your package manager (npm, pnpm, yarn or bun), uses an absolute path for the config so the hook works from any working directory, and is skipped entirely in CI.
+`savvy-commit init` writes its managed sections into the husky hook files using `BEGIN`/`END` markers, so custom commands placed outside the markers survive re-runs. The CI guard lives on each tool line rather than around the entire managed section, so custom hooks outside the managed area still run in CI.
+
+The `savvy-hooks` hygiene section in `post-checkout` and `post-merge` is co-owned with `@savvy-web/lint-staged`: both packages emit byte-identical content and treat the section as idempotent. Whichever tool runs `init` last leaves the section unchanged.
 
 ## Manual setup
 
@@ -110,15 +145,15 @@ To set up without the CLI:
    export default CommitlintConfig.silk();
    ```
 
-2. Run `init` to generate the hook:
+2. Run `init` to generate the hooks:
 
    ```bash
    npx savvy-commit init --config commitlint.config.ts
    # example output (varies by environment)
    ```
 
-3. Or create `.husky/commit-msg` by hand and make it executable:
+3. Or create the husky hooks by hand and make them executable:
 
    ```bash
-   chmod +x .husky/commit-msg
+   chmod +x .husky/commit-msg .husky/post-checkout .husky/post-merge
    ```

--- a/package/README.md
+++ b/package/README.md
@@ -11,7 +11,7 @@ A commitlint config factory that reads your repo and builds the right rules — 
 
 - **Auto-detection** - Reads DCO files, workspace packages and versioning strategy from the repo; no manual wiring required
 - **Zero config** - Ships with working defaults
-- **Type-safe** - Full TypeScript support with Zod schema validation
+- **Type-safe** - Full TypeScript support with Effect Schema validation
 - **Extended types** - Includes `ai`, `release` and `tdd` commit types beyond conventional commits
 - **Interactive prompts** - Built-in commitizen adapter with emoji support
 - **CLI tooling** - Set up and validate configurations with `savvy-commit`

--- a/package/package.json
+++ b/package/package.json
@@ -54,18 +54,17 @@
 		"@effect/printer-ansi": "catalog:silk",
 		"@effect/rpc": "catalog:silk",
 		"@effect/sql": "catalog:silk",
-		"@savvy-web/silk-effects": "^0.4.1",
+		"@savvy-web/silk-effects": "^0.5.0",
 		"effect": "catalog:silk",
-		"shell-quote": "^1.8.3",
-		"workspaces-effect": "^0.5.0",
-		"zod": "^4.4.3"
+		"shell-quote": "^1.8.4",
+		"workspaces-effect": "^1.1.0"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "^21.0.1",
 		"@commitlint/config-conventional": "^21.0.1",
 		"@commitlint/lint": "^21.0.1",
-		"@commitlint/types": "^20.5.0",
-		"@savvy-web/rslib-builder": "^0.20.7",
+		"@commitlint/types": "^21.0.1",
+		"@savvy-web/rslib-builder": "^0.20.8",
 		"@types/node": "catalog:silk",
 		"@types/shell-quote": "^1.7.5",
 		"@typescript/native-preview": "catalog:silk",

--- a/package/src/cli/commands/check.test.ts
+++ b/package/src/cli/commands/check.test.ts
@@ -7,7 +7,7 @@ import { Effect, Layer, LogLevel, Logger } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { WorkspaceDiscovery, WorkspaceRootLive } from "workspaces-effect";
 import { checkCommand } from "./check.js";
-import { generateManagedContent } from "./init.js";
+import { generateManagedContent, initCommand } from "./init.js";
 
 /** Marker format used by silk-effects ManagedSection for "savvy-commit" tool. */
 const BEGIN_MARKER = "# --- BEGIN SAVVY-COMMIT MANAGED SECTION ---";
@@ -20,6 +20,7 @@ const WorkspaceDiscoveryStub = Layer.succeed(
 		listPackages: () => Effect.succeed([]),
 		getPackage: () => Effect.die("not implemented"),
 		importerMap: () => Effect.succeed(new Map()),
+		refresh: () => Effect.void,
 	}),
 );
 
@@ -128,5 +129,21 @@ describe("checkCommand Effect program", () => {
 
 		const handler = checkCommand.handler({});
 		await Effect.runPromise(Effect.provide(handler, TestLayer));
+	});
+
+	it("validates cleanly when fully initialized via init", async () => {
+		const init = initCommand.handler({ force: false, config: "commitlint.config.ts" });
+		await Effect.runPromise(Effect.provide(init, TestLayer));
+
+		const handler = checkCommand.handler({});
+		await Effect.runPromise(Effect.provide(handler, TestLayer));
+
+		// init wrote all three hooks; check should find the base, commit, and hygiene sections present.
+		const fs = await import("node:fs");
+		const commitMsg = fs.readFileSync(join(testDir, ".husky/commit-msg"), "utf8");
+		expect(commitMsg).toContain("# --- BEGIN SAVVY-BASE MANAGED SECTION ---");
+		expect(commitMsg).toContain("# --- BEGIN SAVVY-COMMIT MANAGED SECTION ---");
+		const postCheckout = fs.readFileSync(join(testDir, ".husky/post-checkout"), "utf8");
+		expect(postCheckout).toContain("# --- BEGIN SAVVY-HOOKS MANAGED SECTION ---");
 	});
 });

--- a/package/src/cli/commands/check.ts
+++ b/package/src/cli/commands/check.ts
@@ -5,14 +5,22 @@
  */
 import { Command } from "@effect/cli";
 import { FileSystem } from "@effect/platform";
-import { CheckResult, ManagedSection, VersioningStrategy } from "@savvy-web/silk-effects";
+import {
+	CheckResult,
+	ManagedSection,
+	SavvyBaseSection,
+	SavvyHooksSection,
+	VersioningStrategy,
+	savvyBasePreamble,
+	savvyHooksHygiene,
+} from "@savvy-web/silk-effects";
 import { Effect } from "effect";
 import { WorkspaceDiscovery } from "workspaces-effect";
 import type { ReleaseFormat } from "../../config/schema.js";
 import { detectDCO } from "../../detection/dco.js";
 import { detectScopes } from "../../detection/scopes.js";
-import { CHECK_MARK, HUSKY_HOOK_PATH, WARNING } from "./constants.js";
-import { SECTION_DEF, generateManagedContent } from "./init.js";
+import { CHECK_MARK, HUSKY_HOOK_PATH, POST_CHECKOUT_HOOK_PATH, POST_MERGE_HOOK_PATH, WARNING } from "./constants.js";
+import { SECTION_DEF, savvyCommitBlock } from "./init.js";
 
 /** Unicode cross symbol. */
 const CROSS_MARK = "\u2717";
@@ -128,25 +136,51 @@ export const checkCommand = Command.make("check", {}, () =>
 		}
 
 		// Managed section status
+		let sectionsHealthy = true;
 		if (hasHuskyHook) {
-			const block = yield* ms.read(HUSKY_HOOK_PATH, SECTION_DEF);
+			const baseStatus = yield* ms.check(HUSKY_HOOK_PATH, SavvyBaseSection.block(savvyBasePreamble()));
+			if (CheckResult.$is("Found")(baseStatus) && baseStatus.isUpToDate) {
+				yield* Effect.log(`${CHECK_MARK} Base section: up-to-date`);
+			} else {
+				sectionsHealthy = false;
+				yield* Effect.log(`${WARNING} Base section: outdated or missing (run 'savvy-commit init' to update)`);
+			}
 
+			const block = yield* ms.read(HUSKY_HOOK_PATH, SECTION_DEF);
 			if (block) {
 				const configPath = extractConfigPathFromManaged(block.content);
 				if (configPath) {
-					const expected = SECTION_DEF.block(generateManagedContent(configPath));
-					const status = yield* ms.check(HUSKY_HOOK_PATH, expected);
-
+					const status = yield* ms.check(HUSKY_HOOK_PATH, savvyCommitBlock(configPath));
 					if (CheckResult.$is("Found")(status) && status.isUpToDate) {
-						yield* Effect.log(`${CHECK_MARK} Managed section: up-to-date`);
+						yield* Effect.log(`${CHECK_MARK} Commit section: up-to-date`);
 					} else {
-						yield* Effect.log(`${WARNING} Managed section: outdated (run 'savvy-commit init' to update)`);
+						sectionsHealthy = false;
+						yield* Effect.log(`${WARNING} Commit section: outdated (run 'savvy-commit init' to update)`);
 					}
 				} else {
-					yield* Effect.log(`${WARNING} Managed section: outdated (run 'savvy-commit init' to update)`);
+					sectionsHealthy = false;
+					yield* Effect.log(`${WARNING} Commit section: outdated (run 'savvy-commit init' to update)`);
 				}
 			} else {
-				yield* Effect.log(`${BULLET} Managed section: not found (run 'savvy-commit init' to add)`);
+				sectionsHealthy = false;
+				yield* Effect.log(`${BULLET} Commit section: not found (run 'savvy-commit init' to add)`);
+			}
+		}
+
+		// Hygiene hooks status (co-owned savvy-hooks section)
+		for (const hookPath of [POST_CHECKOUT_HOOK_PATH, POST_MERGE_HOOK_PATH]) {
+			const hygieneExists = yield* fs.exists(hookPath);
+			if (!hygieneExists) {
+				sectionsHealthy = false;
+				yield* Effect.log(`${BULLET} Hygiene hook: ${hookPath} not found (run 'savvy-commit init' to add)`);
+				continue;
+			}
+			const hygieneStatus = yield* ms.check(hookPath, SavvyHooksSection.block(savvyHooksHygiene()));
+			if (CheckResult.$is("Found")(hygieneStatus) && hygieneStatus.isUpToDate) {
+				yield* Effect.log(`${CHECK_MARK} Hygiene hook: ${hookPath}`);
+			} else {
+				sectionsHealthy = false;
+				yield* Effect.log(`${WARNING} Hygiene hook: ${hookPath} outdated (run 'savvy-commit init' to update)`);
 			}
 		}
 
@@ -168,7 +202,7 @@ export const checkCommand = Command.make("check", {}, () =>
 		yield* Effect.log(`  Detected scopes: ${scopeDisplay}`);
 
 		yield* Effect.log("");
-		const hasIssues = !foundConfig || !hasHuskyHook;
+		const hasIssues = !foundConfig || !hasHuskyHook || !sectionsHealthy;
 		if (hasIssues) {
 			yield* Effect.log(`${CROSS_MARK} Commitlint needs configuration. Run: savvy-commit init`);
 		} else {

--- a/package/src/cli/commands/check.ts
+++ b/package/src/cli/commands/check.ts
@@ -36,6 +36,12 @@ const CONFIG_FILES = [
 	"commitlint.config.js",
 	"commitlint.config.mjs",
 	"commitlint.config.cjs",
+	"lib/configs/commitlint.config.ts",
+	"lib/configs/commitlint.config.mts",
+	"lib/configs/commitlint.config.cts",
+	"lib/configs/commitlint.config.js",
+	"lib/configs/commitlint.config.mjs",
+	"lib/configs/commitlint.config.cjs",
 	".commitlintrc",
 	".commitlintrc.json",
 	".commitlintrc.yaml",
@@ -141,9 +147,12 @@ export const checkCommand = Command.make("check", {}, () =>
 			const baseStatus = yield* ms.check(HUSKY_HOOK_PATH, SavvyBaseSection.block(savvyBasePreamble()));
 			if (CheckResult.$is("Found")(baseStatus) && baseStatus.isUpToDate) {
 				yield* Effect.log(`${CHECK_MARK} Base section: up-to-date`);
+			} else if (CheckResult.$is("Found")(baseStatus)) {
+				sectionsHealthy = false;
+				yield* Effect.log(`${WARNING} Base section: outdated (run 'savvy-commit init' to update)`);
 			} else {
 				sectionsHealthy = false;
-				yield* Effect.log(`${WARNING} Base section: outdated or missing (run 'savvy-commit init' to update)`);
+				yield* Effect.log(`${BULLET} Base section: not found (run 'savvy-commit init' to add)`);
 			}
 
 			const block = yield* ms.read(HUSKY_HOOK_PATH, SECTION_DEF);
@@ -178,9 +187,12 @@ export const checkCommand = Command.make("check", {}, () =>
 			const hygieneStatus = yield* ms.check(hookPath, SavvyHooksSection.block(savvyHooksHygiene()));
 			if (CheckResult.$is("Found")(hygieneStatus) && hygieneStatus.isUpToDate) {
 				yield* Effect.log(`${CHECK_MARK} Hygiene hook: ${hookPath}`);
-			} else {
+			} else if (CheckResult.$is("Found")(hygieneStatus)) {
 				sectionsHealthy = false;
 				yield* Effect.log(`${WARNING} Hygiene hook: ${hookPath} outdated (run 'savvy-commit init' to update)`);
+			} else {
+				sectionsHealthy = false;
+				yield* Effect.log(`${BULLET} Hygiene hook: ${hookPath} section not found (run 'savvy-commit init' to add)`);
 			}
 		}
 

--- a/package/src/cli/commands/constants.ts
+++ b/package/src/cli/commands/constants.ts
@@ -5,10 +5,16 @@
  */
 
 /** Unicode checkmark symbol. */
-export const CHECK_MARK = "\u2713";
+export const CHECK_MARK = "✓";
 
 /** Unicode warning symbol. */
-export const WARNING = "\u26A0";
+export const WARNING = "⚠";
 
-/** Husky commit-msg hook path. */
+/** Husky commit-msg hook path (savvy-base + savvy-commit sections). */
 export const HUSKY_HOOK_PATH = ".husky/commit-msg";
+
+/** Husky post-checkout hook path (savvy-hooks hygiene). */
+export const POST_CHECKOUT_HOOK_PATH = ".husky/post-checkout";
+
+/** Husky post-merge hook path (savvy-hooks hygiene). */
+export const POST_MERGE_HOOK_PATH = ".husky/post-merge";

--- a/package/src/cli/commands/init.test.ts
+++ b/package/src/cli/commands/init.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { NodeFileSystem } from "@effect/platform-node";
-import { ManagedSectionLive } from "@savvy-web/silk-effects";
+import { ManagedSectionLive, savvyBasePreamble } from "@savvy-web/silk-effects";
 import { Effect, Layer, LogLevel, Logger } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { generateManagedContent, initCommand } from "./init.js";
@@ -16,32 +16,32 @@ const BEGIN_MARKER = "# --- BEGIN SAVVY-COMMIT MANAGED SECTION ---";
 const END_MARKER = "# --- END SAVVY-COMMIT MANAGED SECTION ---";
 
 describe("generateManagedContent", () => {
-	it("generates shell script with the config path", () => {
+	it("is the one-line savvy-commit tool invocation with the config path", () => {
 		const content = generateManagedContent("lib/configs/commitlint.config.ts");
-		expect(content).toContain('commitlint --config "$ROOT/lib/configs/commitlint.config.ts"');
+		expect(content).toBe('in_ci || pm_exec commitlint --config "$ROOT/lib/configs/commitlint.config.ts" --edit "$1"');
 	});
 
-	it("includes CI skip logic", () => {
+	it("calls the shared pm_exec helper (PM dispatch lives in savvy-base)", () => {
 		const content = generateManagedContent("commitlint.config.ts");
-		expect(content).toContain("$CI");
-		expect(content).toContain("$GITHUB_ACTIONS");
+		expect(content).toContain("pm_exec commitlint");
+		expect(content).toContain("in_ci ||");
+		expect(content).not.toContain("detect_pm");
+		expect(content).not.toContain("$GITHUB_ACTIONS");
 	});
+});
 
-	it("includes package manager detection", () => {
-		const content = generateManagedContent("commitlint.config.ts");
-		expect(content).toContain("detect_pm");
-		expect(content).toContain("pnpm");
-		expect(content).toContain("yarn");
-		expect(content).toContain("bun");
-		expect(content).toContain("npm");
-	});
-
-	it("includes pnpm exec, yarn dlx, bun x, and npx commands", () => {
-		const content = generateManagedContent("my-config.ts");
-		expect(content).toContain("pnpm exec commitlint");
-		expect(content).toContain("yarn dlx commitlint");
-		expect(content).toContain("bun x commitlint");
-		expect(content).toContain("npx --no -- commitlint");
+describe("savvyBasePreamble (shared, re-exported from silk-effects)", () => {
+	it("defines ROOT, in_ci, detect_pm, PM and pm_exec with bun x and exec semantics", () => {
+		const preamble = savvyBasePreamble();
+		expect(preamble).toContain("ROOT=$(git rev-parse --show-toplevel)");
+		expect(preamble).toContain("in_ci()");
+		expect(preamble).toContain("detect_pm()");
+		expect(preamble).toContain("PM=$(detect_pm)");
+		expect(preamble).toContain("pnpm exec");
+		expect(preamble).toContain("yarn exec");
+		expect(preamble).toContain("bun x");
+		expect(preamble).toContain("npx --no --");
+		expect(preamble).not.toContain("yarn dlx");
 	});
 });
 
@@ -111,6 +111,8 @@ describe("initCommand Effect program", () => {
 		const hookContent = readFileSync(join(testDir, ".husky/commit-msg"), "utf8");
 		expect(hookContent).not.toContain("# custom");
 		expect(hookContent).toContain(BEGIN_MARKER);
+		expect(hookContent).toContain("# --- BEGIN SAVVY-BASE MANAGED SECTION ---");
+		expect(hookContent).toContain("pm_exec commitlint");
 	});
 
 	it("does not overwrite existing config without force", async () => {
@@ -145,5 +147,40 @@ describe("initCommand Effect program", () => {
 		const handler = initCommand.handler({ force: false, config: "/absolute/path/config.ts" });
 		const result = await Effect.runPromiseExit(Effect.provide(handler, TestLayer));
 		expect(result._tag).toBe("Failure");
+	});
+
+	it("writes savvy-base before savvy-commit in commit-msg", async () => {
+		const handler = initCommand.handler({ force: false, config: "commitlint.config.ts" });
+		await Effect.runPromise(Effect.provide(handler, TestLayer));
+
+		const hookContent = readFileSync(join(testDir, ".husky/commit-msg"), "utf8");
+		const baseIdx = hookContent.indexOf("# --- BEGIN SAVVY-BASE MANAGED SECTION ---");
+		const commitIdx = hookContent.indexOf(BEGIN_MARKER);
+		expect(baseIdx).toBeGreaterThanOrEqual(0);
+		expect(commitIdx).toBeGreaterThanOrEqual(0);
+		expect(baseIdx).toBeLessThan(commitIdx);
+		expect(hookContent).toContain("pm_exec commitlint --config");
+	});
+
+	it("creates savvy-hooks hygiene in post-checkout and post-merge", async () => {
+		const handler = initCommand.handler({ force: false, config: "commitlint.config.ts" });
+		await Effect.runPromise(Effect.provide(handler, TestLayer));
+
+		for (const hook of [".husky/post-checkout", ".husky/post-merge"]) {
+			const content = readFileSync(join(testDir, hook), "utf8");
+			expect(content).toContain("# --- BEGIN SAVVY-HOOKS MANAGED SECTION ---");
+			expect(content).toContain("git config core.fileMode false");
+			expect(content).toContain("#!/usr/bin/env sh");
+		}
+	});
+
+	it("is idempotent across repeated runs", async () => {
+		const handler = initCommand.handler({ force: false, config: "commitlint.config.ts" });
+		await Effect.runPromise(Effect.provide(handler, TestLayer));
+		const first = readFileSync(join(testDir, ".husky/commit-msg"), "utf8");
+
+		await Effect.runPromise(Effect.provide(handler, TestLayer));
+		const second = readFileSync(join(testDir, ".husky/commit-msg"), "utf8");
+		expect(second).toBe(first);
 	});
 });

--- a/package/src/cli/commands/init.ts
+++ b/package/src/cli/commands/init.ts
@@ -6,9 +6,18 @@
 import { dirname } from "node:path";
 import { Command, Options } from "@effect/cli";
 import { FileSystem } from "@effect/platform";
-import { ManagedSection, SectionDefinition } from "@savvy-web/silk-effects";
+import type { SectionBlock } from "@savvy-web/silk-effects";
+import {
+	ManagedSection,
+	SavvyBaseSection,
+	SavvyHooksSection,
+	SectionDefinition,
+	savvyBasePreamble,
+	savvyHooksHygiene,
+	savvyToolSection,
+} from "@savvy-web/silk-effects";
 import { Effect } from "effect";
-import { CHECK_MARK, HUSKY_HOOK_PATH, WARNING } from "./constants.js";
+import { CHECK_MARK, HUSKY_HOOK_PATH, POST_CHECKOUT_HOOK_PATH, POST_MERGE_HOOK_PATH, WARNING } from "./constants.js";
 
 /** Executable file permission mode. */
 const EXECUTABLE_MODE = 0o755;
@@ -16,85 +25,68 @@ const EXECUTABLE_MODE = 0o755;
 /** Default path for the commitlint config file. */
 const DEFAULT_CONFIG_PATH = "lib/configs/commitlint.config.ts";
 
-/** Section definition for the savvy-commit managed section in shell hooks. */
+/** Section definition for the savvy-commit tool section (identity for read/check/remove). */
 export const SECTION_DEF = SectionDefinition.make({ toolName: "savvy-commit" });
 
+/** Header written when creating a fresh commit-msg hook. */
+const COMMIT_MSG_HEADER =
+	"#!/usr/bin/env sh\n# Commit-msg hook with savvy managed sections\n# Custom hooks can go above, below, or between the managed sections\n\n";
+
+/** Header written when creating a fresh hygiene hook (post-checkout / post-merge). */
+const HYGIENE_HEADER =
+	"#!/usr/bin/env sh\n# Managed by savvy-hooks\n# Custom hooks can go above or below the managed section\n\n";
+
 /**
- * Generate the managed section content for the commit-msg hook.
+ * Build the commitlint command run inside the savvy-commit tool section.
+ *
+ * @param configPath - Path to the commitlint config file (relative to repo root)
+ */
+function commitlintCommand(configPath: string): string {
+	return `commitlint --config "$ROOT/${configPath}" --edit "$1"`;
+}
+
+/**
+ * Build the savvy-commit tool section block for the given config path.
+ *
+ * @remarks
+ * Depends on the savvy-base preamble (`in_ci`, `pm_exec`) preceding it in the hook.
+ *
+ * @remarks
+ * Exported for reuse by the check command, which rebuilds this block to compare against the on-disk section.
+ */
+export function savvyCommitBlock(configPath: string): SectionBlock {
+	return savvyToolSection("savvy-commit", commitlintCommand(configPath));
+}
+
+/**
+ * Rendered content of the savvy-commit tool section.
+ *
+ * @remarks
+ * Named export retained for the check command and tests; equals
+ * `savvyCommitBlock(configPath).content`.
  *
  * @param configPath - Path to the commitlint config file
- * @returns The managed section content (without markers)
  */
 export function generateManagedContent(configPath: string): string {
-	return `# DO NOT EDIT between these markers - managed by savvy-commit
-# Skip managed section in CI environment
-if ! { [ -n "$CI" ] || [ -n "$GITHUB_ACTIONS" ]; }; then
-
-# Get repo root directory
-ROOT=$(git rev-parse --show-toplevel)
-
-# Detect package manager from package.json or lockfiles
-detect_pm() {
-  # Check packageManager field in package.json (e.g., "pnpm@9.0.0")
-  if [ -f "$ROOT/package.json" ]; then
-    pm=$(jq -r '.packageManager // empty' "$ROOT/package.json" 2>/dev/null | cut -d'@' -f1)
-    if [ -n "$pm" ]; then
-      echo "$pm"
-      return
-    fi
-  fi
-
-  # Fallback to lockfile detection
-  if [ -f "$ROOT/pnpm-lock.yaml" ]; then
-    echo "pnpm"
-  elif [ -f "$ROOT/yarn.lock" ]; then
-    echo "yarn"
-  elif [ -f "$ROOT/bun.lock" ]; then
-    echo "bun"
-  else
-    echo "npm"
-  fi
+	return savvyCommitBlock(configPath).content;
 }
 
-# Run commitlint via the detected package manager
-PM=$(detect_pm)
-case "$PM" in
-  pnpm) pnpm exec commitlint --config "$ROOT/${configPath}" --edit "$1" ;;
-  yarn) yarn dlx commitlint --config "$ROOT/${configPath}" --edit "$1" ;;
-  bun)  bun x commitlint --config "$ROOT/${configPath}" --edit "$1" ;;
-  *)    npx --no -- commitlint --config "$ROOT/${configPath}" --edit "$1" ;;
-esac
-
-fi`;
-}
-
-/**
- * Write a fresh hook file with header and managed section.
- *
- * @param path - Hook file path
- * @param configPath - Path to the commitlint config file
- * @returns Effect that creates the hook file
- */
-function writeFullHook(path: string, configPath: string) {
+/** Ensure a hook file exists, writing `header` if it does not. */
+function ensureHookFile(path: string, header: string) {
 	return Effect.gen(function* () {
 		const fs = yield* FileSystem.FileSystem;
-		const ms = yield* ManagedSection;
-		const header =
-			"#!/usr/bin/env sh\n# Commit-msg hook with savvy-commit managed section\n# Custom hooks can go above or below the managed section\n\n";
-		yield* fs.writeFileString(path, header);
-		yield* ms.write(path, SECTION_DEF.block(generateManagedContent(configPath)));
+		const exists = yield* fs.exists(path);
+		if (!exists) {
+			yield* fs.writeFileString(path, header);
+		}
 	});
 }
 
-/** Content for the commitlint config file. */
-const CONFIG_CONTENT = `import { CommitlintConfig } from "@savvy-web/commitlint";
-
-export default CommitlintConfig.silk();
-`;
-
 const forceOption = Options.boolean("force").pipe(
 	Options.withAlias("f"),
-	Options.withDescription("Overwrite entire hook file (not just managed section)"),
+	Options.withDescription(
+		"Overwrite the commit-msg hook and config file entirely (managed sections in post-checkout/post-merge are never force-reset)",
+	),
 	Options.withDefault(false),
 );
 
@@ -104,12 +96,13 @@ const configOption = Options.text("config").pipe(
 	Options.withDefault(DEFAULT_CONFIG_PATH),
 );
 
-/**
- * Make a file executable.
- *
- * @param path - File path to make executable
- * @returns Effect that makes the file executable
- */
+/** Content for the commitlint config file. */
+const CONFIG_CONTENT = `import { CommitlintConfig } from "@savvy-web/commitlint";
+
+export default CommitlintConfig.silk();
+`;
+
+/** Make a file executable. */
 function makeExecutable(path: string) {
 	return Effect.tryPromise(() => import("node:fs/promises").then((fsp) => fsp.chmod(path, EXECUTABLE_MODE)));
 }
@@ -118,12 +111,13 @@ function makeExecutable(path: string) {
  * Init command implementation.
  *
  * @remarks
- * Creates the necessary configuration files for commitlint:
- * - `.husky/commit-msg` hook with managed section
- * - Commitlint config at the specified path
+ * Writes:
+ * - `.husky/commit-msg` — savvy-base preamble + savvy-commit tool section.
+ * - `.husky/post-checkout` and `.husky/post-merge` — savvy-hooks hygiene
+ *   (co-owned with `@savvy-web/lint-staged`; idempotent).
+ * - The commitlint config file.
  *
- * The managed section feature allows users to add custom hooks above/below
- * the savvy-commit section without them being overwritten on updates.
+ * Users may add custom commands above, below, or between the managed sections.
  */
 export const initCommand = Command.make("init", { force: forceOption, config: configOption }, ({ force, config }) =>
 	Effect.gen(function* () {
@@ -136,38 +130,33 @@ export const initCommand = Command.make("init", { force: forceOption, config: co
 
 		yield* Effect.log("Initializing commitlint configuration...\n");
 
-		// Handle husky hook
-		const huskyExists = yield* fs.exists(HUSKY_HOOK_PATH);
+		yield* fs.makeDirectory(".husky", { recursive: true });
 
-		if (huskyExists && !force) {
-			// Sync managed section (creates, updates, or reports unchanged)
-			const block = SECTION_DEF.block(generateManagedContent(config));
-			const result = yield* ms.sync(HUSKY_HOOK_PATH, block);
-			yield* makeExecutable(HUSKY_HOOK_PATH);
-
-			if (result._tag === "Updated") {
-				yield* Effect.log(`${CHECK_MARK} Updated managed section in ${HUSKY_HOOK_PATH}`);
-			} else if (result._tag === "Created") {
-				yield* Effect.log(`${CHECK_MARK} Added managed section to ${HUSKY_HOOK_PATH}`);
-			} else {
-				yield* Effect.log(`${CHECK_MARK} Managed section already up-to-date in ${HUSKY_HOOK_PATH}`);
-			}
-		} else if (huskyExists && force) {
-			// Force: overwrite entire file
-			yield* writeFullHook(HUSKY_HOOK_PATH, config);
-			yield* makeExecutable(HUSKY_HOOK_PATH);
-			yield* Effect.log(`${CHECK_MARK} Replaced ${HUSKY_HOOK_PATH} (--force)`);
+		// commit-msg: savvy-base preamble then savvy-commit tool section, in order.
+		if (force) {
+			yield* fs.writeFileString(HUSKY_HOOK_PATH, COMMIT_MSG_HEADER);
 		} else {
-			// Create new hook
-			yield* fs.makeDirectory(".husky", { recursive: true });
-			yield* writeFullHook(HUSKY_HOOK_PATH, config);
-			yield* makeExecutable(HUSKY_HOOK_PATH);
-			yield* Effect.log(`${CHECK_MARK} Created ${HUSKY_HOOK_PATH}`);
+			yield* ensureHookFile(HUSKY_HOOK_PATH, COMMIT_MSG_HEADER);
+		}
+		const commitResults = yield* ms.syncMany(HUSKY_HOOK_PATH, [
+			SavvyBaseSection.block(savvyBasePreamble()),
+			savvyCommitBlock(config),
+		]);
+		yield* makeExecutable(HUSKY_HOOK_PATH);
+		yield* Effect.log(
+			`${CHECK_MARK} ${force ? "Replaced" : "Synced"} ${HUSKY_HOOK_PATH} (${commitResults.map((r) => r._tag).join(", ")})`,
+		);
+
+		// post-checkout / post-merge: co-owned savvy-hooks hygiene.
+		for (const hookPath of [POST_CHECKOUT_HOOK_PATH, POST_MERGE_HOOK_PATH]) {
+			yield* ensureHookFile(hookPath, HYGIENE_HEADER);
+			yield* ms.sync(hookPath, SavvyHooksSection.block(savvyHooksHygiene()));
+			yield* makeExecutable(hookPath);
+			yield* Effect.log(`${CHECK_MARK} Synced ${hookPath}`);
 		}
 
-		// Handle config file
+		// Config file.
 		const configExists = yield* fs.exists(config);
-
 		if (configExists && !force) {
 			yield* Effect.log(`${WARNING} ${config} already exists (use --force to overwrite)`);
 		} else {

--- a/package/src/config/schema.ts
+++ b/package/src/config/schema.ts
@@ -1,9 +1,9 @@
 /**
- * Zod schemas for commitlint configuration options.
+ * Effect Schemas for commitlint configuration options.
  *
  * @internal
  */
-import { z } from "zod";
+import { Schema } from "effect";
 
 /**
  * Release format schema for the release commit type.
@@ -29,27 +29,38 @@ import { z } from "zod";
  */
 export type ReleaseFormat = "semver" | "packages" | "scoped";
 
-export const ReleaseFormatSchema = z.enum(["semver", "packages", "scoped"]);
+export const ReleaseFormatSchema = Schema.Literal("semver", "packages", "scoped");
 
 /**
- * Zod schema for validating {@link ConfigOptions}.
+ * Effect Schema for validating {@link ConfigOptions}.
  *
  * @remarks
  * This schema validates and applies defaults to user-provided configuration.
- * Used internally by {@link CommitlintConfig.silk}.
+ * Used internally by {@link CommitlintConfig.silk} via {@link decodeConfigOptions}.
  *
  * @internal
  */
-export const ConfigOptionsSchema = z.object({
-	dco: z.boolean().optional(),
-	scopes: z.array(z.string()).optional(),
-	additionalScopes: z.array(z.string()).optional(),
-	releaseFormat: ReleaseFormatSchema.optional(),
-	emojis: z.boolean().default(false),
-	bodyMaxLineLength: z.number().positive().default(300),
-	noMarkdown: z.boolean().default(true),
-	cwd: z.string().optional(),
+export const ConfigOptionsSchema = Schema.Struct({
+	dco: Schema.optional(Schema.Boolean),
+	scopes: Schema.optional(Schema.Array(Schema.String)),
+	additionalScopes: Schema.optional(Schema.Array(Schema.String)),
+	releaseFormat: Schema.optional(ReleaseFormatSchema),
+	emojis: Schema.optionalWith(Schema.Boolean, { default: () => false }),
+	bodyMaxLineLength: Schema.optionalWith(Schema.Number.pipe(Schema.positive()), { default: () => 300 }),
+	noMarkdown: Schema.optionalWith(Schema.Boolean, { default: () => true }),
+	cwd: Schema.optional(Schema.String),
 });
+
+/**
+ * Decode unknown input into {@link ResolvedConfigOptions}, applying defaults.
+ *
+ * @remarks
+ * Synchronous decoder that throws a `ParseError` on invalid input, mirroring
+ * the previous Zod `.parse()` contract used by {@link CommitlintConfig.silk}.
+ *
+ * @internal
+ */
+export const decodeConfigOptions = Schema.decodeUnknownSync(ConfigOptionsSchema);
 
 /**
  * Configuration options for {@link CommitlintConfig.silk}.
@@ -158,7 +169,7 @@ export interface ConfigOptions {
 }
 
 /**
- * Resolved configuration options after Zod parsing applies defaults.
+ * Resolved configuration options after schema decoding applies defaults.
  *
  * @remarks
  * This type represents the options after schema validation, where
@@ -166,4 +177,4 @@ export interface ConfigOptions {
  *
  * @internal
  */
-export type ResolvedConfigOptions = z.output<typeof ConfigOptionsSchema>;
+export type ResolvedConfigOptions = Schema.Schema.Type<typeof ConfigOptionsSchema>;

--- a/package/src/config/schema.ts
+++ b/package/src/config/schema.ts
@@ -6,17 +6,6 @@
 import { Schema } from "effect";
 
 /**
- * Release format schema for the release commit type.
- *
- * @remarks
- * Determines how release commits are formatted based on versioning strategy:
- * - `semver`: `release: v1.2.3` (for single/fixed-group versioning)
- * - `packages`: `release: version packages` (for independent versioning)
- * - `scoped`: `release(pkg): v1.2.3` (for per-package releases)
- *
- * @internal
- */
-/**
  * Release format type for the release commit type.
  *
  * @remarks
@@ -29,6 +18,11 @@ import { Schema } from "effect";
  */
 export type ReleaseFormat = "semver" | "packages" | "scoped";
 
+/**
+ * Effect Schema for {@link ReleaseFormat}.
+ *
+ * @internal
+ */
 export const ReleaseFormatSchema = Schema.Literal("semver", "packages", "scoped");
 
 /**

--- a/package/src/detection/scopes.test.ts
+++ b/package/src/detection/scopes.test.ts
@@ -18,6 +18,7 @@ const EmptyLayer = Layer.succeed(
 		listPackages: () => Effect.succeed([]),
 		getPackage: () => Effect.die("not implemented"),
 		importerMap: () => Effect.succeed(new Map()),
+		refresh: () => Effect.void,
 	}),
 );
 

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -24,7 +24,7 @@
  */
 import { createConfig } from "./config/factory.js";
 import type { ConfigOptions } from "./config/schema.js";
-import { ConfigOptionsSchema } from "./config/schema.js";
+import { decodeConfigOptions } from "./config/schema.js";
 import type { CommitlintUserConfig } from "./config/types.js";
 
 export type { CommitType } from "./config/rules.js";
@@ -108,7 +108,7 @@ export class CommitlintConfig {
 	 * ```
 	 */
 	static silk(options: ConfigOptions = {}): CommitlintUserConfig {
-		const validated = ConfigOptionsSchema.parse(options);
+		const validated = decodeConfigOptions(options);
 		return createConfig(validated);
 	}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ catalogs:
       version: 25.9.1
     '@typescript/native-preview':
       specifier: ^7.0.0-dev.20260523.1
-      version: 7.0.0-dev.20260523.1
+      version: 7.0.0-dev.20260527.1
     effect:
       specifier: ^3.21.2
       version: 3.21.2
@@ -65,10 +65,10 @@ importers:
         version: link:package/dist/dev
       '@savvy-web/lint-staged':
         specifier: ^1.1.0
-        version: 1.1.0(67dc9ee1d7c5535c5ad594325abeec65)
+        version: 1.1.0(bed875f00272b440fdf524474062a7b4)
       '@savvy-web/vitest':
         specifier: ^1.3.2
-        version: 1.3.2(e7443b40b3774a02fa5e23d53eaa1ed0)
+        version: 1.3.2(48351c75a283b5a22fd8feff278966e2)
       bats:
         specifier: ^1.13.0
         version: 1.13.0
@@ -100,20 +100,17 @@ importers:
         specifier: catalog:silk
         version: 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@savvy-web/silk-effects':
-        specifier: ^0.4.1
-        version: 0.4.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+        specifier: ^0.5.0
+        version: 0.5.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       effect:
         specifier: catalog:silk
         version: 3.21.2
       shell-quote:
-        specifier: ^1.8.3
+        specifier: ^1.8.4
         version: 1.8.4
       workspaces-effect:
-        specifier: ^0.5.0
-        version: 0.5.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
-      zod:
-        specifier: ^4.4.3
-        version: 4.4.3
+        specifier: ^1.1.0
+        version: 1.1.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
     devDependencies:
       '@commitlint/cli':
         specifier: ^21.0.1
@@ -125,11 +122,11 @@ importers:
         specifier: ^21.0.1
         version: 21.0.1
       '@commitlint/types':
-        specifier: ^20.5.0
-        version: 20.5.0
+        specifier: ^21.0.1
+        version: 21.0.1
       '@savvy-web/rslib-builder':
-        specifier: ^0.20.7
-        version: 0.20.7(@pnpm/logger@1001.0.1)(@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@typescript/native-preview@7.0.0-dev.20260523.1)(typescript@6.0.3))(@types/node@25.9.1)(@typescript/native-preview@7.0.0-dev.20260523.1)(jiti@2.6.1)(typescript@6.0.3)
+        specifier: ^0.20.8
+        version: 0.20.8(@pnpm/logger@1001.0.1)(@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@typescript/native-preview@7.0.0-dev.20260527.1)(typescript@6.0.3))(@types/node@25.9.1)(@typescript/native-preview@7.0.0-dev.20260527.1)(jiti@2.6.1)(typescript@6.0.3)
       '@types/node':
         specifier: catalog:silk
         version: 25.9.1
@@ -138,7 +135,7 @@ importers:
         version: 1.7.5
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260523.1
+        version: 7.0.0-dev.20260527.1
       commitizen:
         specifier: ^4.3.1
         version: 4.3.1(@types/node@25.9.1)(typescript@6.0.3)
@@ -214,29 +211,29 @@ packages:
     resolution: {integrity: sha512-Hb4o6h1Pf6yRUAX07DR4JVY7dmQw+RVQMW5/m55GoiAT/VRoKCWBtIUPPOnqDVhbx1Cjfil9b6EDrgJsUAujEQ==}
     engines: {node: '>= 10'}
 
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.3':
-    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/runtime@7.29.2':
-    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -365,10 +362,6 @@ packages:
   '@commitlint/top-level@21.0.1':
     resolution: {integrity: sha512-4esUYqzY7K0FCgcJ/1xWEZekV7Ch4yZT1+xjEb7KzqbJ05XEkxHVsTfC8ADKNNtlCE2pj98KEbPGZWw9WwEnVw==}
     engines: {node: '>=22.12.0'}
-
-  '@commitlint/types@20.5.0':
-    resolution: {integrity: sha512-ZJoS8oSq2CAZEpc/YI9SulLrdiIyXeHb/OGqGrkUP6Q7YV+0ouNAa7GjqRdXeQPncHQIDz/jbCTlHScvYvO/gA==}
-    engines: {node: '>=v18'}
 
   '@commitlint/types@21.0.1':
     resolution: {integrity: sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg==}
@@ -602,33 +595,33 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
-    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
-    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    resolution: {integrity: sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==}
     cpu: [x64]
     os: [darwin]
 
-  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
-    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    resolution: {integrity: sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==}
     cpu: [arm64]
     os: [linux]
 
-  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
-    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    resolution: {integrity: sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==}
     cpu: [arm]
     os: [linux]
 
-  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
-    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    resolution: {integrity: sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==}
     cpu: [x64]
     os: [linux]
 
-  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
-    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    resolution: {integrity: sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==}
     cpu: [x64]
     os: [win32]
 
@@ -775,8 +768,8 @@ packages:
     resolution: {integrity: sha512-Zq7m0/2wT/9BgXtk0ue5OC6MeHk+KpbDICmSKybeSy7NQ7sWreiDXhRBnipRLDo21vY7nLuXRsRLopk+3cCmoQ==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/deps.path@1100.0.4':
-    resolution: {integrity: sha512-sEKQFk/EyickTHmDw1rkJ1PIUy8i76I5QsbocJ1/HeO+oLvm2vu7Jmf/7+hny/t6PkyoRioV/YRx4vWSsfuAgQ==}
+  '@pnpm/deps.path@1100.0.5':
+    resolution: {integrity: sha512-Wsbxw5jFSe0PZEpBqfDFZAsLJiZhlSb6fa6mV/h4+dqnvL6FcsErNPBPqUvf/YEQ4zYfpX4oCgjWozaBcmBU0w==}
     engines: {node: '>=22.13'}
 
   '@pnpm/error@1000.1.0':
@@ -791,8 +784,8 @@ packages:
     resolution: {integrity: sha512-rtUWmIKzloHwxgP16PYxTdr3+1lyuBH1JG5Gkgyca32dfmqy3Y55oEfkLywU2NYf/Zvk0C5gHaAMTFZOxuW8kg==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/fetching.fetcher-base@1100.1.5':
-    resolution: {integrity: sha512-Lm8wpqg0AQDuFYNAaL/HddpjPF+JVRFk7IHsueNp8seLTybL4t9+W+45fTM/E5SYPJWlzue7cIHf0Zg9j78syA==}
+  '@pnpm/fetching.fetcher-base@1100.1.6':
+    resolution: {integrity: sha512-QrpOyI5i6rKALBpyOo51UttjrtsQHO5SYY99BaQaIka4r1+NBTDrGiOE5NYGwx9b4ZvJt1OuHy8m+cyyTqHgAA==}
     engines: {node: '>=22.13'}
 
   '@pnpm/fs.graceful-fs@1100.1.0':
@@ -803,26 +796,26 @@ packages:
     resolution: {integrity: sha512-EsMX4slK0qJN2AR0/AYohY5m0HQNYGMNe+jhN74O994zp22/WbX+PbkIKyw3UQn39yQm2+z6SgwklDxbeapsmQ==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/hooks.types@1100.0.8':
-    resolution: {integrity: sha512-6RIiwedtLCAac2gftDHsP1KZs70v6QFzn//PQ+hMcnYq2M9Kt8U5//x9bA9Wxt1aQtRZTamoCVKJBDgK8K7rIg==}
+  '@pnpm/hooks.types@1100.0.9':
+    resolution: {integrity: sha512-Nb/g/56Nt2HdbHLq7M2RIuoUexLj0+8sXnuq9Bak5/Hx7vAIgQP/J6n6yOVRp5I632uFD4m2Dqbwum/UUS5bgw==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/lockfile.fs@1100.1.1':
-    resolution: {integrity: sha512-+yDUe8hTE3+DIPkneh3O7+m+7F4vZRak/W202VSxPWAE1N2imQ4J9QahNYp/U/T7toFZnE7PumHaHScoicOYfw==}
+  '@pnpm/lockfile.fs@1100.1.2':
+    resolution: {integrity: sha512-NulbwgkQGtgcCHS9bCAPcGLjeDKibxOz44GN5SeqW/FimdCNMvKnE0AD/52tlcJwmOAWQqSFQH2p8B9shbZIZg==}
     engines: {node: '>=22.13'}
     peerDependencies:
-      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+      '@pnpm/logger': ^1001.0.1
 
-  '@pnpm/lockfile.merger@1100.0.7':
-    resolution: {integrity: sha512-KIpQwRycrrMxlZFe1Y2tAa0cCynbdcskgA/Ng5iM23VpBKfrbhmYapivXpwVvU1QTezMOmA+ya5fjerEpsoWGA==}
+  '@pnpm/lockfile.merger@1100.0.8':
+    resolution: {integrity: sha512-ifftow+VUQ9yPd+M3gHWuFprW0xm7aut7Rp5Z6wVFNmpJAqUxj7WBicQP0+rQ9V28sogPQOgN8WkR38vbzEHwQ==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/lockfile.types@1100.0.7':
-    resolution: {integrity: sha512-IBaBsC4/zSLM105EBNvlHc4qXVBXgHz6L//+yi2EJDnnSYL8tp6SUn4ZR1RiZjNb7tF9x8UXwySsUqXJ4oWobA==}
+  '@pnpm/lockfile.types@1100.0.8':
+    resolution: {integrity: sha512-+3GLfWIGR6n/wNIivaLvFKpba/0VoT5EWD9u5kxRSeA+kk+y0QYxya/AzHAuveHcRkepQErJb973LtUSD3S6xw==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/lockfile.utils@1100.0.9':
-    resolution: {integrity: sha512-AslLH4xnIVaeEHEcpCuIum9wkrm1uKHz0aU8cRgm44uAE3s7Vd++SgebQ7cKyClNyZ19/hsAHjXrHTZBp6TAKg==}
+  '@pnpm/lockfile.utils@1100.0.10':
+    resolution: {integrity: sha512-nWJYixawEXkyb7EqNfiMtmajvyADGRkCu6nBYNYxXtMiEpBZHgfsRElsQ0Unbi1vwFQho4lYczfrQPmA87ftLQ==}
     engines: {node: '>=22.13'}
 
   '@pnpm/logger@1001.0.1':
@@ -860,8 +853,8 @@ packages:
     resolution: {integrity: sha512-oxf+Y5lumvfNx9Igss/dvDb0t4iWtE0wjrmdDPFkVrXTlQbdWLujnyYSp3Obim/65K+r5RspoizJgjWJRe69nw==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/resolving.resolver-base@1100.3.0':
-    resolution: {integrity: sha512-kHAf0nWq2hSHicdl6CxSJrGEOq1UM1ArggBUa78fmfztUJIvwUHMUDh+NLDXfU072WA5TkltfSBeWPkGi4qEAQ==}
+  '@pnpm/resolving.resolver-base@1100.3.1':
+    resolution: {integrity: sha512-Fx5F52+TiQ7KBuJWOvj47au5vFwQdx4SgKcuswKesSY8EUc1WOBTvva7q0ftWyL6v7hi9jS5HBBEnKO2szg3tA==}
     engines: {node: '>=22.13'}
 
   '@pnpm/semver.peer-range@1000.0.0':
@@ -880,8 +873,8 @@ packages:
     resolution: {integrity: sha512-NLTXheat/u7OEGg5M5vF6Z85zx8uKUZE0+whtX/sbFV2XL48RdnOWGPTKYuVVkv8M+launaLUTgGEXNs/ess2w==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/types@1101.1.1':
-    resolution: {integrity: sha512-uKcYehlSNA5OOHbWnuz0SAl/o/DKBkYqfDjD2FHJV59dP3xTPYR9J6XpZY4+ccKr1Tux2TomtrrPYbG5fXDQIw==}
+  '@pnpm/types@1101.2.0':
+    resolution: {integrity: sha512-SO7vq09NqSQZliBRcrhgfoWkCk3IocbthS6a+lvrcqSSWfttuzhypMGFfnZfmNcNr/BgwUL22oP+eyRM4NMOfw==}
     engines: {node: '>=22.13'}
 
   '@pnpm/util.lex-comparator@3.0.2':
@@ -1140,8 +1133,8 @@ packages:
       '@biomejs/biome':
         optional: true
 
-  '@savvy-web/rslib-builder@0.20.7':
-    resolution: {integrity: sha512-uDkhB5/OWl1rXhw2/B0SNRrZutUVb3j+bU/bs6G1zlHvbOWx8ULMgO0uyDsClKJcp0tPhHMUMjNk+7VIHdMf2g==}
+  '@savvy-web/rslib-builder@0.20.8':
+    resolution: {integrity: sha512-yxE9ZCNYKpFIOPgwFu0Zro0P88zMvvn6cSCHu9N4SmKbZwTJtTwhrWHyV/H8LBr80yWAX6GCbXuG2RvbZAUhAw==}
     peerDependencies:
       '@rsbuild/plugin-react': ^2.0.0
       '@rslib/core': ^0.21.0
@@ -1170,8 +1163,8 @@ packages:
       '@effect/platform': '>=0.96.0'
       effect: '>=3.21.0'
 
-  '@savvy-web/silk-effects@0.4.1':
-    resolution: {integrity: sha512-WK6F4AzkH+oby4FRtGK9Kr26Ef+aSSrBK5ZQ3az5DhQYxl2QDrGNV8oWHJYftvufq078asMU9gu08/3HuiqgqQ==}
+  '@savvy-web/silk-effects@0.5.0':
+    resolution: {integrity: sha512-06yRAuPwytCs4GTJF8bH/PuiUhtX+84eb/0WCpJcvleIAZIOoO5u3J5gid7S+D7qiWCqPXhwJXsSRMyvW/P7iA==}
     peerDependencies:
       '@effect/platform': '>=0.96.0'
       effect: '>=3.21.0'
@@ -1204,8 +1197,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@swc/helpers@0.5.21':
-    resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@trpc/server@11.17.0':
     resolution: {integrity: sha512-jbAOUe0PpUTCYqziyu+8vYXZdDXPudZgnEhWCQ2NjKnVEjfE93RqHTt1oycZJv/HNf51YlRXfEEwSIAbb161rw==}
@@ -1213,33 +1206,33 @@ packages:
     peerDependencies:
       typescript: '>=5.7.2'
 
-  '@turbo/darwin-64@2.9.14':
-    resolution: {integrity: sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A==}
+  '@turbo/darwin-64@2.9.15':
+    resolution: {integrity: sha512-nnDo9R1Df+s2x6jxlERtbg7xRpuicf8p4J2krcnjeaMBt3q9V41pGXa4t9YM2Y4ozozsVJ+CH405CJUrWIQK4Q==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.9.14':
-    resolution: {integrity: sha512-d23147mC9BsCPA9mJ0h/ubcpbRgcJBXbcG3+Vq7YLhjz3IXuvQsJ1UXH8f4MD76ZjJ4m/E4aRdJV+MW88CDfbw==}
+  '@turbo/darwin-arm64@2.9.15':
+    resolution: {integrity: sha512-fDSx56oqoFuS+yUQw7hqjQTkjrSLdMcplhuLC8HcSkWC6YrpwEmUUYsPYHPxy4ALvLxnmPQuk6XoSD8tdkjP+g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.9.14':
-    resolution: {integrity: sha512-P3ZKB5tuUDdDQWuAsACGUR1qv9W7BNWxdxqVJ0kZNuNNPRaVYTPPikLcp79+GiEcW3npsR+KyP38lnQiBc5aSA==}
+  '@turbo/linux-64@2.9.15':
+    resolution: {integrity: sha512-/bmxn+x/xE+oh0VzEXt/zf2zsORAYZPrL3db5/VrXzYt0Z4wxcvffwJBGlSfla2smfS1BLGBiyWldJlWDXJVXA==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.9.14':
-    resolution: {integrity: sha512-ZRTlzcUMrrPv9ZuDzRF9n60Ym13bKeG9jDB8WjxyLhWNzV+AJQN+zdpIk3NJYf2zQsGUm1mNar2P0elRzLw25g==}
+  '@turbo/linux-arm64@2.9.15':
+    resolution: {integrity: sha512-cbOaDe1ijz5As+mimOOHgmRMolZZZO7miNBHHp5xdiYMm2Q/Dwu1JVLx/Kw4s7xjocG/oEoHrpHrxpEAIEfNiw==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.9.14':
-    resolution: {integrity: sha512-exanwN6sIduZwykYeiTQj8kCmOhazP5WOz3bvXMcYtjhL6Z3iRWLewKrXCBq0bqwSP3iBMb/AerRCnHI4lx46A==}
+  '@turbo/windows-64@2.9.15':
+    resolution: {integrity: sha512-/Fzm7afui7uK7dFBwrTXKuDhBBTiHk5I+hMVAPMR7cqQyDo2norCNUsN9PdNuYcmzYbhSOxzz498wQYvSAz29w==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.9.14':
-    resolution: {integrity: sha512-fVdCsnmYoKICsycbWuuGp6Jvi51/3G/UluFWuAUCvR8PIW5IJkAk5BM9UF8PSm0Q2IphWHFZjYEgjHsh3B9y/g==}
+  '@turbo/windows-arm64@2.9.15':
+    resolution: {integrity: sha512-fOHEsLcqVdFXLw2ApWv4gxwfHzkUnpo9rHGml+9+dyHj148m/Bc+556kEvb5+4u6prI1LMd8zEZE2HcO6Jn2VQ==}
     cpu: [arm64]
     os: [win32]
 
@@ -1284,6 +1277,7 @@ packages:
 
   '@types/parse-path@7.1.0':
     resolution: {integrity: sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==}
+    deprecated: This is a stub types definition. parse-path provides its own type definitions, so you do not need this installed.
 
   '@types/shell-quote@1.7.5':
     resolution: {integrity: sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw==}
@@ -1297,8 +1291,8 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@typescript-eslint/parser@8.59.4':
-    resolution: {integrity: sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==}
+  '@typescript-eslint/parser@8.60.0':
+    resolution: {integrity: sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -1310,8 +1304,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/project-service@8.59.4':
-    resolution: {integrity: sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==}
+  '@typescript-eslint/project-service@8.60.0':
+    resolution: {integrity: sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1320,8 +1314,8 @@ packages:
     resolution: {integrity: sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.59.4':
-    resolution: {integrity: sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==}
+  '@typescript-eslint/scope-manager@8.60.0':
+    resolution: {integrity: sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/tsconfig-utils@8.56.1':
@@ -1330,8 +1324,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/tsconfig-utils@8.59.4':
-    resolution: {integrity: sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==}
+  '@typescript-eslint/tsconfig-utils@8.60.0':
+    resolution: {integrity: sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1340,8 +1334,8 @@ packages:
     resolution: {integrity: sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.59.4':
-    resolution: {integrity: sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==}
+  '@typescript-eslint/types@8.60.0':
+    resolution: {integrity: sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.56.1':
@@ -1350,8 +1344,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/typescript-estree@8.59.4':
-    resolution: {integrity: sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==}
+  '@typescript-eslint/typescript-estree@8.60.0':
+    resolution: {integrity: sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1367,54 +1361,54 @@ packages:
     resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/visitor-keys@8.59.4':
-    resolution: {integrity: sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==}
+  '@typescript-eslint/visitor-keys@8.60.0':
+    resolution: {integrity: sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260523.1':
-    resolution: {integrity: sha512-4WHj9v41per176h00j3moITcHpR+8SNoAFdbDuJwUDCJiQkbrCjwulK8UwALxLPEGqyBdNARWcM6GXVTexBg1w==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260527.1':
+    resolution: {integrity: sha512-bDi6FJ644n3uKdp/ZI7j50ChVyGOsrJrkwihQb6x3yByFQkTINLu3e6ZkY+HveQ2Zw2vy9SGN8E7b3A5iSOO0A==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260523.1':
-    resolution: {integrity: sha512-WeVqasFLVwbnwmjLhBTwfNminhaTfCo+ptOW2JT+IgY2WYBGIKXQmhaPPU5bdsHCur7O2RmY5tUAmvqv7V+kog==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260527.1':
+    resolution: {integrity: sha512-r6GXrTdalXZu1/b5goMpAe+efZvOfwdE45gl8Tti3fckP9icK3xdiN+VnNi0RL2/c2L86RyN8nGxihaCHGCKbw==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260523.1':
-    resolution: {integrity: sha512-2Jd0iJOd77LLwsEDFc9O5nfPxvs75d1FafG7BhGGlfD8RtxL4+BzAy8KYI0++TTmHL6aL7+VIr3+TQ58S68Sfw==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260527.1':
+    resolution: {integrity: sha512-QJAFyPJgJqJVLbVPHl5xL7FCn3HNPLdpEm8l7KBgiYpltLhU1p/LJ3iN0XpFRAhq9ojWbZebo8t/h8MX35QjTQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260523.1':
-    resolution: {integrity: sha512-C+fOL4DO/JTLkKT22Bw34FGiUpS4scqC+5AaaCVBCiHWXn1NknSrbvcMWEmg8HzCWPmiUwSQUryNZIFDqi8tUw==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260527.1':
+    resolution: {integrity: sha512-BlfQBatMkZHi3o+atxoUW0czGJNjo9cpO1BoQeB3gxZ7D/cDZHYHmKFSSRx8UxMktwP5k5lPxi0wgA3Ic2mQyQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260523.1':
-    resolution: {integrity: sha512-DiJLdnzh/TolhvDuGxqD1sxlQNnCFLsLLnGPVN6i+/DUPC/cWy0c+5RHruow9lQbtPkZ3aapztkYP2wEP1Ll6Q==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260527.1':
+    resolution: {integrity: sha512-UFB7ZdK2/vIIi62nfn3JhyGV7qR/qXjKPQaPVXwzCvaPieTZcsNsALjKU0W5WHThyi+5p3U7O3dGE7n6P4q4Yw==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260523.1':
-    resolution: {integrity: sha512-axyNrdvX4D6T5ZuZHhufFbPRiKzJyqxusLl5nI3wJqmGN3G5JYCJY9k39LjRYI6oB3ingyKng+3QJ2q7b3IHQA==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260527.1':
+    resolution: {integrity: sha512-rp/q9+9H77JQvepC/UpDP8CdeTGSGyhp9BVbmFwqUV2NhMHPldfys3ihY7OQdoVBgWIKQyxEHB+FTr8Z7kre1Q==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260523.1':
-    resolution: {integrity: sha512-NRBlDy12DLqCC7smCWlEgsiwCxUUl0TAVLUikm+c+WvFhnsY909jk1X8FNUHhNZmR3APHS57AMOq2rreQwHdiQ==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260527.1':
+    resolution: {integrity: sha512-864Pq4qoDcacUJhs2/kQplyfwNO0APUmx1k8qUaJt2P9ZGF0Pu++afJi7OagImHMiEQcmigjmZPuOodOk5YmqQ==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260523.1':
-    resolution: {integrity: sha512-+pkICUeoIbnecsvkEQFmkBC7qQqR5ltQQl+bXuGpKBOURVu2/zDA4i09Ef4KWWD6Kmx7i/EMO2fMZ3IsZEdzPw==}
+  '@typescript/native-preview@7.0.0-dev.20260527.1':
+    resolution: {integrity: sha512-j81qKiwCPgMEjtk8uDLP+TDW60l6mugoJ7SNzfHWv1PJ6bUjIAHuag4P1jSLm1IpKuMuB3TTi4f61n7TJi8Jog==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -1564,8 +1558,8 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-v8-to-istanbul@1.0.0:
-    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
+  ast-v8-to-istanbul@1.0.2:
+    resolution: {integrity: sha512-dKmJxJsGItLmc5CYZKuEjuG6GnBs6PG4gohMhyFOWKaNQoYCuRZJDECaBlHmcG0lv2wc2E0uU8lESmBEumC3DQ==}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -1959,8 +1953,8 @@ packages:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
-  es-toolkit@1.46.1:
-    resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
+  es-toolkit@1.47.0:
+    resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -2271,6 +2265,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-directory@5.0.0:
     resolution: {integrity: sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==}
@@ -2330,8 +2325,8 @@ packages:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
 
-  hono@4.12.22:
-    resolution: {integrity: sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==}
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -2390,6 +2385,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -2787,8 +2783,8 @@ packages:
     resolution: {integrity: sha512-Ajzxb8CM6WAnFjgiloPsI3bF+WCxcvhdIG3KNA2KN962+tdBsHcuQ4k4qX/EcS/2CRkcc0iAkR956Nib6aXU/Q==}
     engines: {node: '>=0.10.0'}
 
-  lru-cache@11.5.0:
-    resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
 
   magic-string@0.30.21:
@@ -2801,8 +2797,8 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
-  markdown-it@14.1.1:
-    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+  markdown-it@14.2.0:
+    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
     hasBin: true
 
   markdown-table@3.0.4:
@@ -3032,8 +3028,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msgpackr-extract@3.0.3:
-    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+  msgpackr-extract@3.0.4:
+    resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
     hasBin: true
 
   msgpackr@1.11.12:
@@ -3702,8 +3698,8 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
@@ -3735,8 +3731,8 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  turbo@2.9.14:
-    resolution: {integrity: sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==}
+  turbo@2.9.15:
+    resolution: {integrity: sha512-VpKvD9Z0Hu/xrGUAYX1wnhfpqv835wIwGqeKfulvBPTOcDap0E3nFwyzCAVV85fB1sBcBDEfTP+7FSW7GzwWSQ==}
     hasBin: true
 
   type-check@0.4.0:
@@ -3767,8 +3763,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.26.0:
+    resolution: {integrity: sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.3.0:
@@ -3943,8 +3939,8 @@ packages:
     resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
     engines: {node: '>= 0.4'}
 
-  which-typed-array@1.1.20:
-    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
+  which-typed-array@1.1.21:
+    resolution: {integrity: sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==}
     engines: {node: '>= 0.4'}
 
   which@1.3.1:
@@ -3973,12 +3969,6 @@ packages:
 
   workspaces-effect@0.4.1:
     resolution: {integrity: sha512-+YBCKKK8PMG4/sPWyslUpX6cH7YTLpEcSsRNEG2kSxLhPXoMEV7XpK6VIWtYs3jdG+wN59M1d+YQnhVaaFB8eQ==}
-    peerDependencies:
-      '@effect/platform': '>=0.96.0'
-      effect: '>=3.21.0'
-
-  workspaces-effect@0.5.1:
-    resolution: {integrity: sha512-f0T2S1rExhNrNNDul+yOs6mWhSWHZYqpSZE/5+TrFUICTH+tXj90j0FpEWBCFnvyHwa1KVV3lPl9U49AyMH54w==}
     peerDependencies:
       '@effect/platform': '>=0.96.0'
       effect: '>=3.21.0'
@@ -4034,11 +4024,6 @@ packages:
 
   yaml-effect@0.2.3:
     resolution: {integrity: sha512-378iw8DWn+6cLzHfOZFLEPu/UXcymHtixKe+CM9OFk9G/uFeQfRU/WNnKRVjIkTCj9M8EwJdiOgH3rOrUwyFyQ==}
-    peerDependencies:
-      effect: '>=3.21.0'
-
-  yaml-effect@0.5.0:
-    resolution: {integrity: sha512-gDqPqryW0BeP5OMfCUZdIAbKGxC4iRJuRRHxEbkHByZRGBCxf0IVgkDEAnwjyRSsIybpK8N3pZodePWmRvNq5g==}
     peerDependencies:
       effect: '>=3.21.0'
 
@@ -4132,26 +4117,26 @@ snapshots:
       '@ast-grep/napi-win32-ia32-msvc': 0.37.0
       '@ast-grep/napi-win32-x64-msvc': 0.37.0
 
-  '@babel/code-frame@7.29.0':
+  '@babel/code-frame@7.29.7':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/helper-string-parser@7.27.1': {}
+  '@babel/helper-string-parser@7.29.7': {}
 
-  '@babel/helper-validator-identifier@7.28.5': {}
+  '@babel/helper-validator-identifier@7.29.7': {}
 
-  '@babel/parser@7.29.3':
+  '@babel/parser@7.29.7':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
-  '@babel/runtime@7.29.2': {}
+  '@babel/runtime@7.29.7': {}
 
-  '@babel/types@7.29.0':
+  '@babel/types@7.29.7':
     dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -4333,7 +4318,7 @@ snapshots:
   '@commitlint/ensure@21.0.1':
     dependencies:
       '@commitlint/types': 21.0.1
-      es-toolkit: 1.46.1
+      es-toolkit: 1.47.0
 
   '@commitlint/execute-rule@21.0.1': {}
 
@@ -4362,7 +4347,7 @@ snapshots:
       '@commitlint/types': 21.0.1
       cosmiconfig: 9.0.1(typescript@6.0.3)
       cosmiconfig-typescript-loader: 6.3.0(@types/node@25.9.1)(cosmiconfig@9.0.1(typescript@6.0.3))(typescript@6.0.3)
-      es-toolkit: 1.46.1
+      es-toolkit: 1.47.0
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
     transitivePeerDependencies:
@@ -4391,7 +4376,7 @@ snapshots:
     dependencies:
       '@commitlint/config-validator': 21.0.1
       '@commitlint/types': 21.0.1
-      es-toolkit: 1.46.1
+      es-toolkit: 1.47.0
       global-directory: 5.0.0
       resolve-from: 5.0.0
 
@@ -4407,11 +4392,6 @@ snapshots:
   '@commitlint/top-level@21.0.1':
     dependencies:
       escalade: 3.2.0
-
-  '@commitlint/types@20.5.0':
-    dependencies:
-      conventional-commits-parser: 6.4.0
-      picocolors: 1.1.1
 
   '@commitlint/types@21.0.1':
     dependencies:
@@ -4474,7 +4454,7 @@ snapshots:
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       effect: 3.21.2
       mime: 3.0.0
-      undici: 7.25.0
+      undici: 7.26.0
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -4578,9 +4558,9 @@ snapshots:
 
   '@gwhitney/detect-indent@7.0.1': {}
 
-  '@hono/node-server@1.19.14(hono@4.12.22)':
+  '@hono/node-server@1.19.14(hono@4.12.23)':
     dependencies:
-      hono: 4.12.22
+      hono: 4.12.23
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -4616,14 +4596,14 @@ snapshots:
 
   '@manypkg/find-root@1.1.0':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
 
   '@manypkg/get-packages@1.1.3':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -4667,7 +4647,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.22)
+      '@hono/node-server': 1.19.14(hono@4.12.23)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -4677,7 +4657,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.22
+      hono: 4.12.23
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -4687,22 +4667,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     optional: true
 
-  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
     optional: true
 
-  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
     optional: true
 
-  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
     optional: true
 
-  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
     optional: true
 
-  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -4813,10 +4793,10 @@ snapshots:
       '@pnpm/fs.graceful-fs': 1100.1.0
       ssri: 13.0.1
 
-  '@pnpm/deps.path@1100.0.4':
+  '@pnpm/deps.path@1100.0.5':
     dependencies:
       '@pnpm/crypto.hash': 1100.0.1
-      '@pnpm/types': 1101.1.1
+      '@pnpm/types': 1101.2.0
       semver: 7.8.1
 
   '@pnpm/error@1000.1.0':
@@ -4839,10 +4819,10 @@ snapshots:
     transitivePeerDependencies:
       - '@pnpm/logger'
 
-  '@pnpm/fetching.fetcher-base@1100.1.5':
+  '@pnpm/fetching.fetcher-base@1100.1.6':
     dependencies:
-      '@pnpm/resolving.resolver-base': 1100.3.0
-      '@pnpm/types': 1101.1.1
+      '@pnpm/resolving.resolver-base': 1100.3.1
+      '@pnpm/types': 1101.2.0
       '@types/ssri': 7.1.5
 
   '@pnpm/fs.graceful-fs@1100.1.0':
@@ -4853,26 +4833,26 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
 
-  '@pnpm/hooks.types@1100.0.8':
+  '@pnpm/hooks.types@1100.0.9':
     dependencies:
-      '@pnpm/fetching.fetcher-base': 1100.1.5
-      '@pnpm/lockfile.types': 1100.0.7
-      '@pnpm/resolving.resolver-base': 1100.3.0
+      '@pnpm/fetching.fetcher-base': 1100.1.6
+      '@pnpm/lockfile.types': 1100.0.8
+      '@pnpm/resolving.resolver-base': 1100.3.1
       '@pnpm/store.cafs-types': 1100.0.1
-      '@pnpm/types': 1101.1.1
+      '@pnpm/types': 1101.2.0
 
-  '@pnpm/lockfile.fs@1100.1.1(@pnpm/logger@1001.0.1)':
+  '@pnpm/lockfile.fs@1100.1.2(@pnpm/logger@1001.0.1)':
     dependencies:
       '@pnpm/constants': 1100.0.0
-      '@pnpm/deps.path': 1100.0.4
+      '@pnpm/deps.path': 1100.0.5
       '@pnpm/error': 1100.0.0
-      '@pnpm/lockfile.merger': 1100.0.7
-      '@pnpm/lockfile.types': 1100.0.7
-      '@pnpm/lockfile.utils': 1100.0.9
+      '@pnpm/lockfile.merger': 1100.0.8
+      '@pnpm/lockfile.types': 1100.0.8
+      '@pnpm/lockfile.utils': 1100.0.10
       '@pnpm/logger': 1001.0.1
       '@pnpm/network.git-utils': 1100.0.1
       '@pnpm/object.key-sorting': 1100.0.0
-      '@pnpm/types': 1101.1.1
+      '@pnpm/types': 1101.2.0
       '@zkochan/rimraf': 4.0.0
       comver-to-semver: 2.0.0
       js-yaml: '@zkochan/js-yaml@0.0.11'
@@ -4882,28 +4862,28 @@ snapshots:
       strip-bom: 5.0.0
       write-file-atomic: 7.0.1
 
-  '@pnpm/lockfile.merger@1100.0.7':
+  '@pnpm/lockfile.merger@1100.0.8':
     dependencies:
-      '@pnpm/lockfile.types': 1100.0.7
-      '@pnpm/types': 1101.1.1
+      '@pnpm/lockfile.types': 1100.0.8
+      '@pnpm/types': 1101.2.0
       comver-to-semver: 2.0.0
       ramda: '@pnpm/ramda@0.28.1'
       semver: 7.8.1
 
-  '@pnpm/lockfile.types@1100.0.7':
+  '@pnpm/lockfile.types@1100.0.8':
     dependencies:
       '@pnpm/patching.types': 1100.0.0
-      '@pnpm/resolving.resolver-base': 1100.3.0
-      '@pnpm/types': 1101.1.1
+      '@pnpm/resolving.resolver-base': 1100.3.1
+      '@pnpm/types': 1101.2.0
 
-  '@pnpm/lockfile.utils@1100.0.9':
+  '@pnpm/lockfile.utils@1100.0.10':
     dependencies:
-      '@pnpm/deps.path': 1100.0.4
+      '@pnpm/deps.path': 1100.0.5
       '@pnpm/error': 1100.0.0
-      '@pnpm/hooks.types': 1100.0.8
-      '@pnpm/lockfile.types': 1100.0.7
-      '@pnpm/resolving.resolver-base': 1100.3.0
-      '@pnpm/types': 1101.1.1
+      '@pnpm/hooks.types': 1100.0.9
+      '@pnpm/lockfile.types': 1100.0.8
+      '@pnpm/resolving.resolver-base': 1100.3.1
+      '@pnpm/types': 1101.2.0
       get-npm-tarball-url: 2.1.0
       ramda: '@pnpm/ramda@0.28.1'
 
@@ -4955,9 +4935,9 @@ snapshots:
     dependencies:
       '@pnpm/error': 1000.1.0
 
-  '@pnpm/resolving.resolver-base@1100.3.0':
+  '@pnpm/resolving.resolver-base@1100.3.1':
     dependencies:
-      '@pnpm/types': 1101.1.1
+      '@pnpm/types': 1101.2.0
 
   '@pnpm/semver.peer-range@1000.0.0':
     dependencies:
@@ -4971,7 +4951,7 @@ snapshots:
 
   '@pnpm/types@1001.3.0': {}
 
-  '@pnpm/types@1101.1.1': {}
+  '@pnpm/types@1101.2.0': {}
 
   '@pnpm/util.lex-comparator@3.0.2': {}
 
@@ -5043,15 +5023,15 @@ snapshots:
 
   '@rsbuild/core@2.0.7':
     dependencies:
-      '@rspack/core': 2.0.4(@swc/helpers@0.5.21)
-      '@swc/helpers': 0.5.21
+      '@rspack/core': 2.0.4(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@typescript/native-preview@7.0.0-dev.20260523.1)(typescript@6.0.3)':
+  '@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@typescript/native-preview@7.0.0-dev.20260527.1)(typescript@6.0.3)':
     dependencies:
       '@rsbuild/core': 2.0.7
-      rsbuild-plugin-dts: 0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@rsbuild/core@2.0.7)(@typescript/native-preview@7.0.0-dev.20260523.1)(typescript@6.0.3)
+      rsbuild-plugin-dts: 0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@rsbuild/core@2.0.7)(@typescript/native-preview@7.0.0-dev.20260527.1)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@25.9.1)
       typescript: 6.0.3
@@ -5107,11 +5087,11 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.0.4
       '@rspack/binding-win32-x64-msvc': 2.0.4
 
-  '@rspack/core@2.0.4(@swc/helpers@0.5.21)':
+  '@rspack/core@2.0.4(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.0.4
     optionalDependencies:
-      '@swc/helpers': 0.5.21
+      '@swc/helpers': 0.5.23
 
   '@rushstack/node-core-library@5.23.1(@types/node@25.9.1)':
     dependencies:
@@ -5183,14 +5163,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@savvy-web/lint-staged@1.1.0(67dc9ee1d7c5535c5ad594325abeec65)':
+  '@savvy-web/lint-staged@1.1.0(bed875f00272b440fdf524474062a7b4)':
     dependencies:
       '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/platform': 0.96.1(effect@3.21.2)
       '@effect/platform-node': 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@savvy-web/silk-effects': 0.3.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@types/node': 25.9.1
-      '@typescript/native-preview': 7.0.0-dev.20260523.1
+      '@typescript/native-preview': 7.0.0-dev.20260527.1
       effect: 3.21.2
       husky: 9.1.7
       jsonc-effect: 0.2.1(effect@3.21.2)
@@ -5199,7 +5179,7 @@ snapshots:
       markdownlint-cli2-formatter-codequality: 0.0.7(markdownlint-cli2@0.22.1)
       prettier: 3.8.3
       sort-package-json: 3.6.1
-      turbo: 2.9.14
+      turbo: 2.9.15
       typescript: 6.0.3
       workspaces-effect: 1.1.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       yaml: 2.9.0
@@ -5213,7 +5193,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@savvy-web/rslib-builder@0.20.7(@pnpm/logger@1001.0.1)(@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@typescript/native-preview@7.0.0-dev.20260523.1)(typescript@6.0.3))(@types/node@25.9.1)(@typescript/native-preview@7.0.0-dev.20260523.1)(jiti@2.6.1)(typescript@6.0.3)':
+  '@savvy-web/rslib-builder@0.20.8(@pnpm/logger@1001.0.1)(@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@typescript/native-preview@7.0.0-dev.20260527.1)(typescript@6.0.3))(@types/node@25.9.1)(@typescript/native-preview@7.0.0-dev.20260527.1)(jiti@2.6.1)(typescript@6.0.3)':
     dependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@25.9.1)
       '@microsoft/tsdoc': 0.16.0
@@ -5221,20 +5201,20 @@ snapshots:
       '@pnpm/catalogs.config': 1100.0.0
       '@pnpm/catalogs.protocol-parser': 1100.0.0
       '@pnpm/exportable-manifest': 1000.4.2(@pnpm/logger@1001.0.1)
-      '@pnpm/lockfile.fs': 1100.1.1(@pnpm/logger@1001.0.1)
+      '@pnpm/lockfile.fs': 1100.1.2(@pnpm/logger@1001.0.1)
       '@pnpm/workspace.read-manifest': 1000.3.1
       '@rsbuild/core': 2.0.7
-      '@rslib/core': 0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@typescript/native-preview@7.0.0-dev.20260523.1)(typescript@6.0.3)
+      '@rslib/core': 0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@typescript/native-preview@7.0.0-dev.20260527.1)(typescript@6.0.3)
       '@types/node': 25.9.1
-      '@typescript-eslint/parser': 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)
-      '@typescript/native-preview': 7.0.0-dev.20260523.1
+      '@typescript-eslint/parser': 8.60.0(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript/native-preview': 7.0.0-dev.20260527.1
       deep-equal: 2.2.3
       eslint: 10.4.0(jiti@2.6.1)
       eslint-plugin-tsdoc: 0.5.2(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)
       glob: 13.0.6
       picocolors: 1.1.1
       sort-package-json: 3.6.1
-      tmp: 0.2.5
+      tmp: 0.2.7
       typescript: 6.0.3
       workspace-tools: 0.41.7
     transitivePeerDependencies:
@@ -5253,7 +5233,7 @@ snapshots:
       workspaces-effect: 0.4.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       yaml-effect: 0.2.3(effect@3.21.2)
 
-  '@savvy-web/silk-effects@0.4.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)':
+  '@savvy-web/silk-effects@0.5.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)':
     dependencies:
       '@effect/platform': 0.96.1(effect@3.21.2)
       effect: 3.21.2
@@ -5262,10 +5242,10 @@ snapshots:
       workspaces-effect: 1.1.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       yaml-effect: 0.6.0(effect@3.21.2)
 
-  '@savvy-web/vitest@1.3.2(e7443b40b3774a02fa5e23d53eaa1ed0)':
+  '@savvy-web/vitest@1.3.2(48351c75a283b5a22fd8feff278966e2)':
     dependencies:
       '@types/node': 25.9.1
-      '@typescript/native-preview': 7.0.0-dev.20260523.1
+      '@typescript/native-preview': 7.0.0-dev.20260527.1
       '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
       typescript: 6.0.3
       vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.9.0))
@@ -5284,7 +5264,7 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@swc/helpers@0.5.21':
+  '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
 
@@ -5292,22 +5272,22 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@turbo/darwin-64@2.9.14':
+  '@turbo/darwin-64@2.9.15':
     optional: true
 
-  '@turbo/darwin-arm64@2.9.14':
+  '@turbo/darwin-arm64@2.9.15':
     optional: true
 
-  '@turbo/linux-64@2.9.14':
+  '@turbo/linux-64@2.9.15':
     optional: true
 
-  '@turbo/linux-arm64@2.9.14':
+  '@turbo/linux-arm64@2.9.15':
     optional: true
 
-  '@turbo/windows-64@2.9.14':
+  '@turbo/windows-64@2.9.15':
     optional: true
 
-  '@turbo/windows-arm64@2.9.14':
+  '@turbo/windows-arm64@2.9.15':
     optional: true
 
   '@tybys/wasm-util@0.10.2':
@@ -5362,12 +5342,12 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/parser@8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.60.0(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.59.4
-      '@typescript-eslint/types': 8.59.4
-      '@typescript-eslint/typescript-estree': 8.59.4(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.59.4
+      '@typescript-eslint/scope-manager': 8.60.0
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.60.0
       debug: 4.4.3
       eslint: 10.4.0(jiti@2.6.1)
       typescript: 6.0.3
@@ -5376,17 +5356,17 @@ snapshots:
 
   '@typescript-eslint/project-service@8.56.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@6.0.3)
-      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@6.0.3)
+      '@typescript-eslint/types': 8.56.1
       debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.59.4(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.60.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@6.0.3)
-      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/tsconfig-utils': 8.60.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.60.0
       debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -5397,22 +5377,22 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
 
-  '@typescript-eslint/scope-manager@8.59.4':
+  '@typescript-eslint/scope-manager@8.60.0':
     dependencies:
-      '@typescript-eslint/types': 8.59.4
-      '@typescript-eslint/visitor-keys': 8.59.4
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/visitor-keys': 8.60.0
 
   '@typescript-eslint/tsconfig-utils@8.56.1(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/tsconfig-utils@8.59.4(typescript@6.0.3)':
+  '@typescript-eslint/tsconfig-utils@8.60.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
 
   '@typescript-eslint/types@8.56.1': {}
 
-  '@typescript-eslint/types@8.59.4': {}
+  '@typescript-eslint/types@8.60.0': {}
 
   '@typescript-eslint/typescript-estree@8.56.1(typescript@6.0.3)':
     dependencies:
@@ -5429,12 +5409,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.59.4(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.60.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.59.4(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@6.0.3)
-      '@typescript-eslint/types': 8.59.4
-      '@typescript-eslint/visitor-keys': 8.59.4
+      '@typescript-eslint/project-service': 8.60.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.60.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/visitor-keys': 8.60.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.1
@@ -5460,47 +5440,47 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
 
-  '@typescript-eslint/visitor-keys@8.59.4':
+  '@typescript-eslint/visitor-keys@8.60.0':
     dependencies:
-      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/types': 8.60.0
       eslint-visitor-keys: 5.0.1
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260523.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260527.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260523.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260527.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260523.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260527.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260523.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260527.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260523.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260527.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260523.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260527.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260523.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260527.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260523.1':
+  '@typescript/native-preview@7.0.0-dev.20260527.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260523.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260523.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260523.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260523.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260523.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260523.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260523.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260527.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260527.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260527.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260527.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260527.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260527.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260527.1
 
   '@vitest/coverage-v8@4.1.7(vitest@4.1.7)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.7
-      ast-v8-to-istanbul: 1.0.0
+      ast-v8-to-istanbul: 1.0.2
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
@@ -5648,7 +5628,7 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  ast-v8-to-istanbul@1.0.0:
+  ast-v8-to-istanbul@1.0.2:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
@@ -5948,7 +5928,7 @@ snapshots:
       side-channel: 1.1.0
       which-boxed-primitive: 1.1.1
       which-collection: 1.0.2
-      which-typed-array: 1.1.20
+      which-typed-array: 1.1.21
 
   deep-extend@0.6.0: {}
 
@@ -6058,7 +6038,7 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
-  es-toolkit@1.46.1: {}
+  es-toolkit@1.47.0: {}
 
   escalade@3.2.0: {}
 
@@ -6231,7 +6211,7 @@ snapshots:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
-      tmp: 0.2.5
+      tmp: 0.2.7
 
   fast-check@3.23.2:
     dependencies:
@@ -6506,7 +6486,7 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hono@4.12.22: {}
+  hono@4.12.23: {}
 
   html-escaper@2.0.2: {}
 
@@ -6902,7 +6882,7 @@ snapshots:
 
   longest@2.0.1: {}
 
-  lru-cache@11.5.0: {}
+  lru-cache@11.5.1: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -6910,15 +6890,15 @@ snapshots:
 
   magicast@0.5.3:
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
     dependencies:
       semver: 7.8.1
 
-  markdown-it@14.1.1:
+  markdown-it@14.2.0:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
@@ -6943,7 +6923,7 @@ snapshots:
       js-yaml: 4.1.1
       jsonc-parser: 3.3.1
       jsonpointer: 5.0.1
-      markdown-it: 14.1.1
+      markdown-it: 14.2.0
       markdownlint: 0.40.0
       markdownlint-cli2-formatter-default: 0.0.6(markdownlint-cli2@0.22.1)
       micromatch: 4.0.8
@@ -7334,21 +7314,21 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msgpackr-extract@3.0.3:
+  msgpackr-extract@3.0.4:
     dependencies:
       node-gyp-build-optional-packages: 5.2.2
     optionalDependencies:
-      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
     optional: true
 
   msgpackr@1.11.12:
     optionalDependencies:
-      msgpackr-extract: 3.0.3
+      msgpackr-extract: 3.0.4
 
   multipasta@0.2.7: {}
 
@@ -7498,7 +7478,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -7532,7 +7512,7 @@ snapshots:
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.5.0
+      lru-cache: 11.5.1
       minipass: 7.1.3
 
   path-to-regexp@8.4.2: {}
@@ -7744,13 +7724,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@rsbuild/core@2.0.7)(@typescript/native-preview@7.0.0-dev.20260523.1)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@rsbuild/core@2.0.7)(@typescript/native-preview@7.0.0-dev.20260527.1)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.0.7
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@25.9.1)
-      '@typescript/native-preview': 7.0.0-dev.20260523.1
+      '@typescript/native-preview': 7.0.0-dev.20260527.1
       typescript: 6.0.3
 
   run-async@2.4.1: {}
@@ -8036,7 +8016,7 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  tmp@0.2.5: {}
+  tmp@0.2.7: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -8060,14 +8040,14 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  turbo@2.9.14:
+  turbo@2.9.15:
     optionalDependencies:
-      '@turbo/darwin-64': 2.9.14
-      '@turbo/darwin-arm64': 2.9.14
-      '@turbo/linux-64': 2.9.14
-      '@turbo/linux-arm64': 2.9.14
-      '@turbo/windows-64': 2.9.14
-      '@turbo/windows-arm64': 2.9.14
+      '@turbo/darwin-64': 2.9.15
+      '@turbo/darwin-arm64': 2.9.15
+      '@turbo/linux-64': 2.9.15
+      '@turbo/linux-arm64': 2.9.15
+      '@turbo/windows-64': 2.9.15
+      '@turbo/windows-arm64': 2.9.15
 
   type-check@0.4.0:
     dependencies:
@@ -8089,7 +8069,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.25.0: {}
+  undici@7.26.0: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -8251,7 +8231,7 @@ snapshots:
       is-weakmap: 2.0.2
       is-weakset: 2.0.4
 
-  which-typed-array@1.1.20:
+  which-typed-array@1.1.21:
     dependencies:
       available-typed-arrays: 1.0.7
       call-bind: 1.0.9
@@ -8303,15 +8283,6 @@ snapshots:
       semver-effect: 0.2.1(effect@3.21.2)
       yaml-effect: 0.2.3(effect@3.21.2)
 
-  workspaces-effect@0.5.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2):
-    dependencies:
-      '@effect/platform': 0.96.1(effect@3.21.2)
-      effect: 3.21.2
-      jsonc-effect: 0.2.1(effect@3.21.2)
-      minimatch: 10.2.5
-      semver-effect: 0.2.1(effect@3.21.2)
-      yaml-effect: 0.5.0(effect@3.21.2)
-
   workspaces-effect@1.1.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2):
     dependencies:
       '@effect/platform': 0.96.1(effect@3.21.2)
@@ -8360,10 +8331,6 @@ snapshots:
   y18n@5.0.8: {}
 
   yaml-effect@0.2.3(effect@3.21.2):
-    dependencies:
-      effect: 3.21.2
-
-  yaml-effect@0.5.0(effect@3.21.2):
     dependencies:
       effect: 3.21.2
 


### PR DESCRIPTION
## Summary

Splits the husky hook managed sections so a shared `savvy-base` preamble (package-manager detection + `in_ci` / `pm_exec` helpers) is one section and the `commitlint` invocation is a one-line `savvy-commit` tool section, ordered via silk-effects' new `ManagedSection.syncMany`. Repo hygiene (`git config core.fileMode false` + chmod of tracked `.sh`) moves to a co-owned `savvy-hooks` section in `.husky/post-checkout` and `.husky/post-merge`. The package-manager runner is standardized on local `exec` semantics (`pnpm exec` / `yarn exec` / `bun x` / `npx --no`), fixing the prior `yarn dlx` / `bunx` inconsistency.

- `savvy-commit init` writes `.husky/commit-msg` as ordered `savvy-base` + `savvy-commit` (via `ManagedSection.syncMany`), plus the co-owned `savvy-hooks` hygiene in `.husky/post-checkout` and `.husky/post-merge`. Users can inject custom shell above, below, or between the managed sections.
- `savvy-commit check` validates the `savvy-base`, `savvy-commit`, and `savvy-hooks` sections independently and factors section health into its verdict.
- Requires `@savvy-web/silk-effects@^0.5.0` (ships `syncMany`, `remove`, and the shared `savvyBasePreamble` / `savvyHooksHygiene` / `savvyToolSection` generators).

Also bundled on this branch:

- `workspaces-effect` bumped to v1.1.0; `WorkspaceDiscovery` gained `refresh()`; test stubs updated.
- `config/schema.ts` migrated from `zod` to Effect Schema; `zod` removed from dependencies. `CommitlintConfig.silk` public shape and defaults unchanged; the thrown validation error type changes from `ZodError` to a Schema `ParseError`.

## Changesets

- `.changeset/fancy-bears-swim.md` — `@savvy-web/commitlint` **minor**
- `.changeset/clever-cups-laugh.md` — `@savvy-web/commitlint` **patch** (dependency updates)

## Test Plan

- [x] `pnpm build` — typecheck + dev + prod green
- [x] `pnpm test` — 293 vitest specs pass
- [x] `/smoketest` — 76/76 (types, dco, markdown, tdd across hook + CLI paths)
- [ ] CI green against published `@savvy-web/silk-effects@0.5.0`

## Follow-up (separate repo)

`@savvy-web/lint-staged` should adopt the same shared sections — build `pre-commit` via `syncMany([savvy-base, savvyToolSection("savvy-lint", …)])`, write the `savvy-hooks` hygiene, and `remove` its old `SAVVY-LINT` hygiene sections to migrate the rename.

Signed-off-by: C. Spencer Beggs <spencer@savvyweb.systems>
